### PR TITLE
Explicit Groups

### DIFF
--- a/benchmarks/test_benchmark_maze.py
+++ b/benchmarks/test_benchmark_maze.py
@@ -4,7 +4,7 @@ from itertools import product
 import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Specification, Synthesizer
-from cosy.types import Constructor, Literal, Type, Var
+from cosy.types import Constructor, Group, Literal, Type, Var
 
 
 def is_free(pos: tuple[int, int]) -> bool:
@@ -37,41 +37,48 @@ def component_specifications() -> (
     def pos(ab: str) -> Type:
         return Constructor("pos", Var(ab))
 
+    class Int2(Group):
+        name = "int2"
+        _positions = frozenset(filter(is_free, product(range(SIZE), range(SIZE))))
+
+        def __contains__(self, x):
+            return x in self._positions
+
+        def __iter__(self):
+            yield from self._positions
+
+    int2 = Int2()
+
     return {
         up: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         down: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         left: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         right: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
-        "START": "pos" @ (Literal((0, 0), "int2")),
+        "START": "pos" @ (Literal((0, 0))),
     }
 
 
 SIZE = 50
 
 
-@pytest.fixture
-def literals():
-    return {"int2": frozenset(filter(is_free, product(range(SIZE), range(SIZE))))}
+def test_benchmark_maze(component_specifications, benchmark):
+    fin = "pos" @ (Literal((SIZE - 1, SIZE - 1)))
 
-
-def test_benchmark_maze(component_specifications, literals, benchmark):
-    fin = "pos" @ (Literal((SIZE - 1, SIZE - 1), "int2"))
-
-    synthesizer = Synthesizer(component_specifications, literals)
+    synthesizer = Synthesizer(component_specifications)
     benchmark(synthesizer.construct_solution_space, fin)

--- a/benchmarks/test_benchmark_maze.py
+++ b/benchmarks/test_benchmark_maze.py
@@ -4,7 +4,7 @@ from itertools import product
 import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Specification, Synthesizer
-from cosy.types import Constructor, Group, Literal, Type, Var
+from cosy.types import Constructor, DataGroup, Literal, Type, Var
 
 
 def is_free(pos: tuple[int, int]) -> bool:
@@ -37,17 +37,7 @@ def component_specifications() -> (
     def pos(ab: str) -> Type:
         return Constructor("pos", Var(ab))
 
-    class Int2(Group):
-        name = "int2"
-        _positions = frozenset(filter(is_free, product(range(SIZE), range(SIZE))))
-
-        def __contains__(self, x):
-            return x in self._positions
-
-        def __iter__(self):
-            yield from self._positions
-
-    int2 = Int2()
+    int2 = DataGroup("int2", frozenset(filter(is_free, product(range(SIZE), range(SIZE)))))
 
     return {
         up: DSL()

--- a/benchmarks/test_benchmark_maze_contains.py
+++ b/benchmarks/test_benchmark_maze_contains.py
@@ -1,9 +1,9 @@
-from collections.abc import Callable, Container, Mapping
+from collections.abc import Callable, Mapping
 
 import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Specification, Synthesizer
-from cosy.types import Constructor, Literal, Type, Var
+from cosy.types import Constructor, Group, Literal, Type, Var
 
 
 def is_free(pos: tuple[int, int]) -> bool:
@@ -12,6 +12,9 @@ def is_free(pos: tuple[int, int]) -> bool:
     if row == col:
         return True
     return pow(11, (row + col + seed) * (row + col + seed) + col + 7, 1000003) % 5 > 0
+
+
+SIZE = 50
 
 
 @pytest.fixture
@@ -36,54 +39,49 @@ def component_specifications() -> (
     def pos(ab: str) -> Type:
         return Constructor("pos", Var(ab))
 
+    class Int2(Group):
+        name = "int2"
+
+        # represents the set of all free positions
+        def __contains__(self, value: object) -> bool:
+            if isinstance(value, tuple):
+                x, y = value
+                if isinstance(x, int) and isinstance(y, int) and 0 <= x < SIZE and 0 <= y < SIZE and is_free((x, y)):
+                    return True
+            return False
+
+    int2 = Int2()
+
     return {
         up: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         down: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         left: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
         right: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .suffix(pos("b")),
-        "START": "pos" @ (Literal((0, 0), "int2")),
+        "START": "pos" @ (Literal((0, 0))),
     }
-
-
-SIZE = 50
-
-
-class Pos(Container):
-    # represents the set of all free positions
-    def __contains__(self, value: object) -> bool:
-        if isinstance(value, tuple):
-            x, y = value
-            if isinstance(x, int) and isinstance(y, int) and 0 <= x < SIZE and 0 <= y < SIZE and is_free((x, y)):
-                return True
-        return False
-
-
-@pytest.fixture
-def literals():
-    return {"int2": Pos()}
 
 
 @pytest.fixture
 def fin():
-    return "pos" @ (Literal((SIZE - 1, SIZE - 1), "int2"))
+    return "pos" @ (Literal((SIZE - 1, SIZE - 1)))
 
 
-def test_benchmark_maze_contains(component_specifications, literals, fin, benchmark):
-    synthesizer = Synthesizer(component_specifications, literals)
+def test_benchmark_maze_contains(component_specifications, fin, benchmark):
+    synthesizer = Synthesizer(component_specifications)
     benchmark(synthesizer.construct_solution_space, fin)

--- a/benchmarks/test_benchmark_maze_contains.py
+++ b/benchmarks/test_benchmark_maze_contains.py
@@ -50,6 +50,9 @@ def component_specifications() -> (
                     return True
             return False
 
+        def __iter__(self):
+            pass
+
     int2 = Int2()
 
     return {

--- a/benchmarks/test_benchmark_maze_loopfree.py
+++ b/benchmarks/test_benchmark_maze_loopfree.py
@@ -5,7 +5,7 @@ import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Specification, Synthesizer
 from cosy.tree import Tree
-from cosy.types import Constructor, Group, Literal, Type, Var
+from cosy.types import Constructor, DataGroup, Literal, Type, Var
 
 
 def is_free(pos: tuple[int, int]) -> bool:
@@ -50,17 +50,7 @@ def component_specifications() -> (
         yield (0, 0)
         return
 
-    class Int2(Group):
-        name = "int2"
-        _positions = frozenset(filter(is_free, product(range(SIZE), range(SIZE))))
-
-        def __contains__(self, x):
-            return x in self._positions
-
-        def __iter__(self):
-            yield from self._positions
-
-    int2 = Int2()
+    int2 = DataGroup("int2", frozenset(filter(is_free, product(range(SIZE), range(SIZE)))))
 
     return {
         up: DSL()

--- a/benchmarks/test_benchmark_maze_loopfree.py
+++ b/benchmarks/test_benchmark_maze_loopfree.py
@@ -5,7 +5,7 @@ import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Specification, Synthesizer
 from cosy.tree import Tree
-from cosy.types import Constructor, Literal, Type, Var
+from cosy.types import Constructor, Group, Literal, Type, Var
 
 
 def is_free(pos: tuple[int, int]) -> bool:
@@ -50,45 +50,52 @@ def component_specifications() -> (
         yield (0, 0)
         return
 
+    class Int2(Group):
+        name = "int2"
+        _positions = frozenset(filter(is_free, product(range(SIZE), range(SIZE))))
+
+        def __contains__(self, x):
+            return x in self._positions
+
+        def __iter__(self):
+            yield from self._positions
+
+    int2 = Int2()
+
     return {
         up: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] + 1)])
         .argument("pos", pos("a"))
         .constraint(lambda vs: vs["b"] not in getpath(vs["pos"]))
         .suffix(pos("b")),
         down: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0], vs["b"][1] - 1)])
         .argument("pos", pos("a"))
         .constraint(lambda vs: vs["b"] not in getpath(vs["pos"]))
         .suffix(pos("b")),
         left: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] + 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .constraint(lambda vs: vs["b"] not in getpath(vs["pos"]))
         .suffix(pos("b")),
         right: DSL()
-        .parameter("b", "int2")
-        .parameter("a", "int2", lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
+        .parameter("b", int2)
+        .parameter("a", int2, lambda vs: [(vs["b"][0] - 1, vs["b"][1])])
         .argument("pos", pos("a"))
         .constraint(lambda vs: vs["b"] not in getpath(vs["pos"]))
         .suffix(pos("b")),
-        "START": "pos" @ (Literal((0, 0), "int2")),
+        "START": "pos" @ (Literal((0, 0))),
     }
 
 
 SIZE = 50
 
 
-@pytest.fixture
-def literals():
-    return {"int2": frozenset(filter(is_free, product(range(SIZE), range(SIZE))))}
+def test_benchmark_maze(component_specifications, benchmark):
+    fin = "pos" @ (Literal((SIZE - 1, SIZE - 1)))
 
-
-def test_benchmark_maze(component_specifications, literals, benchmark):
-    fin = "pos" @ (Literal((SIZE - 1, SIZE - 1), "int2"))
-
-    synthesizer = Synthesizer(component_specifications, literals)
+    synthesizer = Synthesizer(component_specifications)
     benchmark(synthesizer.construct_solution_space, fin)

--- a/docs/features/constraints.md
+++ b/docs/features/constraints.md
@@ -63,7 +63,7 @@ class RegularExpression(Container): # (1)!
 
 parameter_space = {"regular_expression": RegularExpression()}
 cosy = CoSy(component_specifications, parameter_space) # (2)!
-query: Type = Constructor("matches", Literal("01+0", "regular_expression")) # (3)!
+query: Type = Constructor("matches", Literal("01+0")) # (3)!
  
 for solution in cosy.solve(query): # (4)!
     print(solution)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,7 @@ Using domain-specific language provided by the `DSL` class define a mapping of c
 
 - The component `fib_zero` is specified by `Constructor("fib") & Constructor("at", Literal(0, "int"))`, which combines two properties.
   + `Constructor("fib")` means that `fib_zero` it is a Fibonacci number.
-  + `Constructor("at", Literal(0, "int"))` means that `fib_zero` is associated with index `0`.
+  + `Constructor("at", Literal(0))` means that `fib_zero` is associated with index `0`.
 - The component `fib_one`, similarly to `fib_zero`, is a Fibonacci number and is associated with index `1`.
 - The component `fib_next` has three parameters associated with the group `int`
   + `z` index of the constructed Fibonacci number
@@ -33,10 +33,10 @@ def fib_next(_z: int, _y: int, _x: int, f1 : int, f2: int) -> int:
 
 component_specifications = {
     fib_zero: DSL()
-          .suffix(Constructor("fib") & Constructor("at", Literal(0, "int"))),
+          .suffix(Constructor("fib") & Constructor("at", Literal(0))),
 
     fib_one: DSL()
-          .suffix(Constructor("fib") & Constructor("at", Literal(1, "int"))),
+          .suffix(Constructor("fib") & Constructor("at", Literal(1))),
 
     fib_next: DSL()
               .parameter("z", "int")
@@ -90,11 +90,11 @@ for solution in cosy.solve(query):
 ### Fibonacci numbers at Specific Indices
 
 The specification allows us to query Fibonacci numbers at specific indices.
-For an index `i` the query `Constructor("fib") & Constructor("at", Literal(i, "int"))` describes the Fibonacci number at index `i`.
+For an index `i` the query `Constructor("fib") & Constructor("at", Literal(i))` describes the Fibonacci number at index `i`.
 Using the `solve` method, construct and display this Fibonacci number.
 
 ```
 for i in range(20):
-    query = Constructor("fib") & Constructor("at", Literal(i, "int"))
+    query = Constructor("fib") & Constructor("at", Literal(i))
     print(i, next(iter(cosy.solve(query))))
 ```

--- a/examples/example_constraints.py
+++ b/examples/example_constraints.py
@@ -61,6 +61,9 @@ def main():
         def __contains__(self, value: object) -> bool:
             return isinstance(value, str)
 
+        def __iter__(self):
+            pass
+
     component_specifications = {
         empty: DSL().suffix(Constructor("str")),
         zero: DSL().argument("s", Constructor("str")).suffix(Constructor("str")),

--- a/examples/example_constraints.py
+++ b/examples/example_constraints.py
@@ -4,11 +4,10 @@ Demonstrates constraints in CoSy.
 """
 
 import re
-from collections.abc import Container
 
 from cosy import CoSy
 from cosy.dsl import DSL
-from cosy.types import Constructor, Literal, Type, Var
+from cosy.types import Constructor, Group, Literal, Type, Var
 
 
 def empty() -> str:
@@ -55,30 +54,30 @@ def is_heavy(s: str) -> bool:
 
 
 def main():
+    # regular expressions
+    class RegularExpression(Group):
+        name = "regex"
+
+        def __contains__(self, value: object) -> bool:
+            return isinstance(value, str)
+
     component_specifications = {
         empty: DSL().suffix(Constructor("str")),
         zero: DSL().argument("s", Constructor("str")).suffix(Constructor("str")),
         one: DSL().argument("s", Constructor("str")).suffix(Constructor("str")),
         fin: DSL()
-        .parameter("r", "regular_expression")
+        .parameter("r", RegularExpression())
         .argument("s", Constructor("str"))
         # parameter constraint to ensure that s matches the regular expression r
         .constraint(lambda vs: re.fullmatch(vs["r"], vs["s"].interpret()))
         .suffix(Constructor("matches", Var("r"))),
     }
 
-    # regular expressions
-    class RegularExpression(Container):
-        def __contains__(self, value: object) -> bool:
-            return isinstance(value, str)
-
-    parameter_space = {"regular_expression": RegularExpression()}
-
     # CoSy instance with the component specifications and parameter space
-    cosy = CoSy(component_specifications, parameter_space)
+    cosy = CoSy(component_specifications)
 
     # query for heavy strings
-    query: Type = Constructor("matches", Literal("01+0", "regular_expression"))
+    query: Type = Constructor("matches", Literal("01+0"))
 
     # solve the query and print the solutions
     for solution in cosy.solve(query):

--- a/examples/example_fibonacci.py
+++ b/examples/example_fibonacci.py
@@ -5,7 +5,7 @@ Overall description of this example goes here.
 
 from cosy import CoSy
 from cosy.dsl import DSL
-from cosy.types import Constructor, Group, Literal, Type, Var
+from cosy.types import Constructor, DataGroup, Literal, Type, Var
 
 
 def fib_zero() -> int:
@@ -43,19 +43,15 @@ def fib_next(_z: int, _y: int, _x: int, f1: int, f2: int) -> int:
 
 def main():
     # range of relevant indices for Fibonacci numbers
-    class Int(Group):
-        name = "int"
-
-        def __iter__(self):
-            yield from range(20)
+    bound = 20
 
     component_specifications = {
         fib_zero: DSL().suffix(Constructor("fib") & Constructor("at", Literal(0))),
         fib_one: DSL().suffix(Constructor("fib") & Constructor("at", Literal(1))),
         fib_next: DSL()
-        .parameter("z", Int())
-        .parameter("y", Int(), lambda vs: [vs["z"] - 1])
-        .parameter("x", Int(), lambda vs: [vs["z"] - 2])
+        .parameter("z", DataGroup("int", range(bound)))
+        .parameter("y", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 1])
+        .parameter("x", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 2])
         .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
         .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
         .suffix(Constructor("fib") & Constructor("at", Var("z"))),

--- a/examples/example_fibonacci.py
+++ b/examples/example_fibonacci.py
@@ -5,7 +5,7 @@ Overall description of this example goes here.
 
 from cosy import CoSy
 from cosy.dsl import DSL
-from cosy.types import Constructor, Literal, Type, Var
+from cosy.types import Constructor, Group, Literal, Type, Var
 
 
 def fib_zero() -> int:
@@ -42,23 +42,27 @@ def fib_next(_z: int, _y: int, _x: int, f1: int, f2: int) -> int:
 
 
 def main():
+    # range of relevant indices for Fibonacci numbers
+    class Int(Group):
+        name = "int"
+
+        def __iter__(self):
+            yield from range(20)
+
     component_specifications = {
-        fib_zero: DSL().suffix(Constructor("fib") & Constructor("at", Literal(0, "int"))),
-        fib_one: DSL().suffix(Constructor("fib") & Constructor("at", Literal(1, "int"))),
+        fib_zero: DSL().suffix(Constructor("fib") & Constructor("at", Literal(0))),
+        fib_one: DSL().suffix(Constructor("fib") & Constructor("at", Literal(1))),
         fib_next: DSL()
-        .parameter("z", "int")
-        .parameter("y", "int", lambda vs: [vs["z"] - 1])
-        .parameter("x", "int", lambda vs: [vs["z"] - 2])
+        .parameter("z", Int())
+        .parameter("y", Int(), lambda vs: [vs["z"] - 1])
+        .parameter("x", Int(), lambda vs: [vs["z"] - 2])
         .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
         .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
         .suffix(Constructor("fib") & Constructor("at", Var("z"))),
     }
 
-    # range of relevant indices for Fibonacci numbers
-    parameter_space = {"int": list(range(20))}
-
     # CoSy instance with the component specifications and parameter space
-    cosy = CoSy(component_specifications, parameter_space)
+    cosy = CoSy(component_specifications)
 
     # query for Fibonacci numbers at relevant indices
     query: Type = Constructor("fib")
@@ -69,7 +73,7 @@ def main():
 
     for i in range(20):
         # query for Fibonacci numbers at index i
-        query = Constructor("fib") & Constructor("at", Literal(i, "int"))
+        query = Constructor("fib") & Constructor("at", Literal(i))
 
         # solve the query and print the only solution
         print(i, next(iter(cosy.solve(query))))

--- a/examples/example_fibonacci_linear.py
+++ b/examples/example_fibonacci_linear.py
@@ -5,7 +5,7 @@ Overall description of this example goes here.
 
 from cosy import CoSy
 from cosy.dsl import DSL
-from cosy.types import Constructor, Literal, Var
+from cosy.types import Constructor, Group, Literal, Var
 
 
 def fst(_x: int, f: tuple[int, int]) -> int:
@@ -41,27 +41,35 @@ def fib_next(_y: int, _x: int, f: tuple[int, int]) -> tuple[int, int]:
 
 
 def main():
+    # range of relevant indices for Fibonacci numbers
+    class Int(Group):
+        name = "int"
+        _bound = 6000
+
+        def __contains__(self, item: object) -> bool:
+            return isinstance(item, int) and 0 <= item < self._bound
+
+        def __iter__(self):
+            yield from frozenset(range(self._bound))
+
     component_specifications = {
         fst: DSL()
-        .parameter("x", "int")
+        .parameter("x", Int())
         .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
         .suffix(Constructor("fib") & Constructor("at", Var("x"))),
-        fib_zero_one: DSL().suffix(Constructor("fibs") & Constructor("at", Literal(0, "int"))),
+        fib_zero_one: DSL().suffix(Constructor("fibs") & Constructor("at", Literal(0))),
         fib_next: DSL()
-        .parameter("y", "int")
-        .parameter("x", "int", lambda vs: [vs["y"] - 1])
+        .parameter("y", Int())
+        .parameter("x", Int(), lambda vs: [vs["y"] - 1])
         .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
         .suffix(Constructor("fibs") & Constructor("at", Var("y"))),
     }
 
-    # range of relevant indices for Fibonacci numbers
-    parameter_space = {"int": frozenset(range(6000))}
-
     # CoSy instance with the component specifications and parameter space
-    cosy = CoSy(component_specifications, parameter_space)
+    cosy = CoSy(component_specifications)
 
     # query for the Fibonacci number at index 5000
-    query = Constructor("fib") & Constructor("at", Literal(5000, "int"))
+    query = Constructor("fib") & Constructor("at", Literal(5000))
 
     # solve the query and print the only solution
     print("5000th Fibonacci number:", next(iter(cosy.solve(query))))

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, TypeVar
 from cosy.dsl import DSL
 from cosy.solution_space import SolutionSpace
 from cosy.subtypes import Subtypes, Taxonomy
-from cosy.synthesizer import ParameterSpace, Specification, Synthesizer
+from cosy.synthesizer import Specification, Synthesizer
 from cosy.types import Arrow, Constructor, Intersection, Literal, Omega, Type, Var
 
 __all__ = [
@@ -26,20 +26,17 @@ T = TypeVar("T", bound=Hashable)
 
 class CoSy(Generic[T]):
     component_specifications: Mapping[T, Specification]
-    parameter_space: ParameterSpace | None = None
     taxonomy: Taxonomy | None = None
     _synthesizer: Synthesizer
 
     def __init__(
         self,
         component_specifications: Mapping[T, Specification],
-        parameter_space: ParameterSpace | None = None,
         taxonomy: Taxonomy | None = None,
     ) -> None:
         self.component_specifications = component_specifications
-        self.parameter_space = parameter_space
         self.taxonomy = taxonomy if taxonomy is not None else {}
-        self._synthesizer = Synthesizer(component_specifications, parameter_space, self.taxonomy)
+        self._synthesizer = Synthesizer(component_specifications, self.taxonomy)
 
     def solve(self, query: Type, max_count: int = 100) -> Iterable[Any]:
         """

--- a/src/cosy/dsl.py
+++ b/src/cosy/dsl.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from cosy.types import (
     Abstraction,
+    Group,
     Implication,
     LiteralParameter,
     Predicate,
@@ -57,13 +58,13 @@ class DSL:
     def parameter(  #
         self,
         name: str,
-        group: str,
+        group: Group,
         candidates: Callable[[dict[str, Any]], Sequence[Any]] | None = None,
     ) -> DSL:
         """
         Introduce a new parameter variable.
 
-        `group` is a string, and an instance of this specification will be generated
+        `group` is a Group, and an instance of this specification will be generated
         for each valid literal in the corresponding literal group.
         You can use this variable as Var(name) in all `Type`s, after the introduction
         and in all predicates.
@@ -75,7 +76,7 @@ class DSL:
         :param name: The name of the new variable.
         :type name: str
         :param group: The group of the variable.
-        :type group: str
+        :type group: Group
         :param candidates: Parameterized sequence of candidate values, that will be used to generate the literals.
         :type candidates: Callable[[dict[str, Any]], Sequence[Any]] | None
         :return: The DSL object.

--- a/src/cosy/inspector.py
+++ b/src/cosy/inspector.py
@@ -9,11 +9,12 @@ from collections.abc import Hashable, Mapping
 from itertools import chain
 from typing import TypeVar
 
-from cosy.synthesizer import ParameterSpace, Specification, Taxonomy
+from cosy.synthesizer import Specification, Taxonomy
 from cosy.types import (
     Abstraction,
     Arrow,
     Constructor,
+    Group,
     Implication,
     Intersection,
     LiteralParameter,
@@ -62,7 +63,6 @@ class Inspector:
     def inspect(
         self,
         component_specifications: Mapping[C, Specification],
-        parameter_space: ParameterSpace | None = None,
         taxonomy: Taxonomy | None = None,
     ):
         """
@@ -80,19 +80,16 @@ class Inspector:
         - a concept in the taxonomy is not used in any component
         """
 
-        if parameter_space is None:
-            parameter_space = {}
-
         if taxonomy is None:
             taxonomy = {}
 
-        all_groups: set[tuple[str, str | Type]] = set()
+        all_groups: set[tuple[str, Group | Type]] = set()
         all_constructors: list[set[str]] = []
 
         for specification in component_specifications.values():
             prefix: list[LiteralParameter | TermParameter] = []
             # mapping from variable names to groups
-            groups: dict[str, str | Type] = {}
+            groups: dict[str, Group | Type] = {}
             # set of parameter names occurring in bodies
             parameter_names: set[str] = set()
             parameterized_type = specification
@@ -118,10 +115,6 @@ class Inspector:
                                     g,
                                 )
                         all_groups.add((param.name, param.group))
-                    if isinstance(param, LiteralParameter) and param.group not in parameter_space:
-                        # check if group is defined in the parameter space
-                        msg = f"Group {param.group} is not defined in the parameter space"
-                        raise ValueError(msg)
                     if isinstance(param, TermParameter):
                         parameter_names.update(param.group.free_vars)
                         constructors.update(Inspector._constructors(param.group))
@@ -142,13 +135,6 @@ class Inspector:
             for var, group in groups.items():
                 if isinstance(group, str) and var not in parameter_names:
                     self._logger.info("Variable %s is abstracted via a parameter but not used", var)
-
-        all_group_names = {g for n, g in all_groups if isinstance(g, str)}
-
-        # check if every group is used
-        for group in parameter_space:
-            if group not in all_group_names:
-                self._logger.info("Group %s is not used in any component", group)
 
         # check is some constructor is used only in one component
         for constructors in all_constructors:

--- a/src/cosy/solution_space.py
+++ b/src/cosy/solution_space.py
@@ -21,7 +21,6 @@ G = TypeVar("G", bound=Hashable)  # type of constants
 class ConstantArgument(Generic[T, G]):
     name: str
     value: T
-    origin: G
 
 
 @dataclass(frozen=True)

--- a/src/cosy/solution_space.py
+++ b/src/cosy/solution_space.py
@@ -21,6 +21,7 @@ G = TypeVar("G", bound=Hashable)  # type of constants
 class ConstantArgument(Generic[T, G]):
     name: str
     value: T
+    origin: G
 
 
 @dataclass(frozen=True)

--- a/src/cosy/subtypes.py
+++ b/src/cosy/subtypes.py
@@ -21,20 +21,19 @@ class Subtypes:
         self,
         subtypes: deque[Type],
         supertype: Type,
-        groups: Mapping[str, str],
         substitutions: Mapping[str, Literal],
     ) -> bool:
         if supertype.is_omega:
             return True
         match supertype:
-            case Literal(value2, group2):
+            case Literal(value2):
                 while subtypes:
                     match subtypes.pop():
-                        case Literal(value1, group1):
-                            if value2 == value1 and group1 == group2:
+                        case Literal(value1):
+                            if value2 == value1:
                                 return True
                         case Var(name1):
-                            if groups[name1] == supertype.group and substitutions[name1] == supertype.value:
+                            if substitutions[name1] == supertype.value:
                                 return True
                         case Intersection(l, r):
                             subtypes.extend((l, r))
@@ -48,26 +47,26 @@ class Subtypes:
                                 casted_constr.append(arg1)
                         case Intersection(l, r):
                             subtypes.extend((l, r))
-                return len(casted_constr) != 0 and self._check_subtype_rec(casted_constr, arg2, groups, substitutions)
+                return len(casted_constr) != 0 and self._check_subtype_rec(casted_constr, arg2, substitutions)
             case Arrow(src2, tgt2):
                 casted_arr: deque[Type] = deque()
                 while subtypes:
                     match subtypes.pop():
                         case Arrow(src1, tgt1):
-                            if self._check_subtype_rec(deque((src2,)), src1, groups, substitutions):
+                            if self._check_subtype_rec(deque((src2,)), src1, substitutions):
                                 casted_arr.append(tgt1)
                         case Intersection(l, r):
                             subtypes.extend((l, r))
-                return len(casted_arr) != 0 and self._check_subtype_rec(casted_arr, tgt2, groups, substitutions)
+                return len(casted_arr) != 0 and self._check_subtype_rec(casted_arr, tgt2, substitutions)
             case Intersection(l, r):
-                return self._check_subtype_rec(subtypes.copy(), l, groups, substitutions) and self._check_subtype_rec(
-                    subtypes, r, groups, substitutions
+                return self._check_subtype_rec(subtypes.copy(), l, substitutions) and self._check_subtype_rec(
+                    subtypes, r, substitutions
                 )
             case Var(name):
                 while subtypes:
                     match subtypes.pop():
-                        case Literal(value, group):
-                            if groups[name] == group and substitutions[name] == value:
+                        case Literal(value):
+                            if substitutions[name] == value:
                                 return True
                         case Intersection(l, r):
                             subtypes.extend((l, r))
@@ -80,24 +79,23 @@ class Subtypes:
         self,
         subtype: Type,
         supertype: Type,
-        groups: Mapping[str, str],
         substitutions: Mapping[str, Literal],
     ) -> bool:
         """Decides whether subtype <= supertype with respect to intersection type subtyping."""
 
-        return self._check_subtype_rec(deque((subtype,)), supertype, groups, substitutions)
+        return self._check_subtype_rec(deque((subtype,)), supertype, substitutions)
 
-    def infer_substitution(self, subtype: Type, path: Type, groups: Mapping[str, str]) -> dict[str, Any] | None:
-        """Infers a unique substitution S such that S(subtype) <= path where path is closed. Returns None or Ambiguous is no solution exists or multiple solutions exist respectively."""
+    def infer_substitution(self, subtype: Type, path: Type) -> dict[str, Any] | None:
+        """Infers a unique substitution S such that S(subtype) <= path where path is closed. Returns None or Ambiguous is no solution exists or multiple solutions exist respectively. Does not respect groups."""
 
         if subtype.is_omega:
             return None
 
         match subtype:
-            case Literal(value1, group1):
+            case Literal(value1):
                 match path:
-                    case Literal(value2, group2):
-                        if value1 == value2 and group1 == group2:
+                    case Literal(value2):
+                        if value1 == value2:
                             return {}
             case Constructor(name1, arg1):
                 match path:
@@ -105,21 +103,21 @@ class Subtypes:
                         if name2 == name1 or name2 in self.taxonomy.get(name1, {}):
                             if arg2.is_omega:
                                 return {}
-                            return self.infer_substitution(arg1, arg2, groups)
+                            return self.infer_substitution(arg1, arg2)
             case Arrow(src1, tgt1):
                 match path:
                     case Arrow(src2, tgt2):
-                        substitution = self.infer_substitution(tgt1, tgt2, groups)
+                        substitution = self.infer_substitution(tgt1, tgt2)
                         if substitution is None:
                             return None
                         if all(name in substitution for name in src1.free_vars):
-                            if self.check_subtype(src2, src1, groups, substitution):
+                            if self.check_subtype(src2, src1, substitution):
                                 return substitution
                             return None
                         return {}  # there are actual non-Ambiguous cases (relevant in practice?)
             case Intersection(l, r):
-                substitution1 = self.infer_substitution(l, path, groups)
-                substitution2 = self.infer_substitution(r, path, groups)
+                substitution1 = self.infer_substitution(l, path)
+                substitution2 = self.infer_substitution(r, path)
                 if substitution1 is None:
                     return substitution2
                 if substitution2 is None:
@@ -135,9 +133,8 @@ class Subtypes:
                 return {}
             case Var(name):
                 match path:
-                    case Literal(value2, group2):
-                        if groups[name] == group2:
-                            return {name: value2}
+                    case Literal(value2):  # here a contains check in the group could be done
+                        return {name: value2}
             case _:
                 msg = f"Unsupported type in infer_substitution: {subtype}"
                 raise TypeError(msg)

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -68,7 +68,6 @@ class MultiArrow:
 class CombinatorInfo:
     # container for auxiliary information about a combinator
     prefix: list[LiteralParameter | TermParameter | Predicate]
-    groups: dict[str, Group]
     term_predicates: tuple[Callable[[dict[str, Any]], bool], ...]
     instantiations: deque[dict[str, Any]] | None
     type: list[list[MultiArrow]]
@@ -102,7 +101,7 @@ class Synthesizer(Generic[C]):
 
         prefix: list[LiteralParameter | TermParameter | Predicate] = []
         variables: set[str] = set()
-        groups: dict[str, Group] = {}
+        literal_variables: set[str] = set()
         while not isinstance(parameterized_type, Type):
             if isinstance(parameterized_type, Abstraction):
                 param = parameterized_type.parameter
@@ -113,11 +112,11 @@ class Synthesizer(Generic[C]):
                 variables.add(param.name)
                 if isinstance(param, LiteralParameter):
                     prefix.append(param)
-                    groups[param.name] = param.group
+                    literal_variables.add(param.name)
                 elif isinstance(param, TermParameter):
                     prefix.append(param)
                     for free_var in param.group.free_vars:
-                        if free_var not in groups:
+                        if free_var not in literal_variables:
                             # check if each parameter variable is abstracted
                             msg = f"Parameter {free_var} is not abstracted."
                             raise ValueError(msg)
@@ -127,7 +126,7 @@ class Synthesizer(Generic[C]):
                 parameterized_type = parameterized_type.body
 
         for free_var in parameterized_type.free_vars:
-            if free_var not in groups:
+            if free_var not in literal_variables:
                 # check if each parameter variable is abstracted
                 msg = f"Parameter {free_var} is not abstracted."
                 raise ValueError(msg)
@@ -146,7 +145,7 @@ class Synthesizer(Generic[C]):
         term_predicates: tuple[Callable[[dict[str, Any]], bool], ...] = tuple(
             p.constraint for p in prefix if isinstance(p, Predicate) and not p.only_literals
         )
-        return CombinatorInfo(prefix, groups, term_predicates, None, multiarrows)
+        return CombinatorInfo(prefix, term_predicates, None, multiarrows)
 
     def _enumerate_substitutions(
         self,

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -338,6 +338,7 @@ class Synthesizer(Generic[C]):
                                         ConstantArgument(
                                             param.name,
                                             instantiation[param.name],
+                                            param.group,
                                         )
                                         if isinstance(param, LiteralParameter)
                                         else NonTerminalArgument(
@@ -362,7 +363,7 @@ class Synthesizer(Generic[C]):
                                 )
                                 yield (
                                     current_target,
-                                    RHSRule[Type, Any, str](
+                                    RHSRule[Type, Any, Group](
                                         (*named_arguments, *anonymous_arguments),
                                         combinator_info.term_predicates,
                                         combinator,
@@ -370,10 +371,10 @@ class Synthesizer(Generic[C]):
                                 )
                                 stack.extendleft((q.origin, None) for q in anonymous_arguments)
 
-    def construct_solution_space(self, *targets: Type) -> SolutionSpace[Type, C, str]:
+    def construct_solution_space(self, *targets: Type) -> SolutionSpace[Type, C, Group]:
         """Constructs a logic program in the current environment for the given target types."""
 
-        solution_space: SolutionSpace[Type, C, str] = SolutionSpace()
+        solution_space: SolutionSpace[Type, C, Group] = SolutionSpace()
         for nt, rule in self.construct_solution_space_rules(*targets):
             solution_space.add_rule(nt, rule.terminal, rule.arguments, rule.predicates)
 

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -108,7 +108,7 @@ class Synthesizer(Generic[C]):
                 param = parameterized_type.parameter
                 if param.name in variables:
                     # check if parameter names are unique
-                    msg = f"Duplicate name {param.name} in specification of combinator {str(combinator)}."
+                    msg = f"Duplicate name {param.name} in specification of combinator {combinator!s}."
                     raise ValueError(msg)
                 variables.add(param.name)
                 if isinstance(param, LiteralParameter):
@@ -119,7 +119,9 @@ class Synthesizer(Generic[C]):
                     for free_var in param.group.free_vars:
                         if free_var not in literal_variables:
                             # check if each parameter variable is abstracted
-                            msg = f"Parameter {free_var} is not abstracted in specification of combinator {str(combinator)}."
+                            msg = (
+                                f"Parameter {free_var} is not abstracted in specification of combinator {combinator!s}."
+                            )
                             raise ValueError(msg)
                 parameterized_type = parameterized_type.body
             elif isinstance(parameterized_type, Implication):
@@ -129,7 +131,7 @@ class Synthesizer(Generic[C]):
         for free_var in parameterized_type.free_vars:
             if free_var not in literal_variables:
                 # check if each parameter variable is abstracted
-                msg = f"Parameter {free_var} is not abstracted in specification of combinator {str(combinator)}."
+                msg = f"Parameter {free_var} is not abstracted in specification of combinator {combinator!s}."
                 raise ValueError(msg)
 
         current: list[MultiArrow] = [MultiArrow((), parameterized_type)]

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -8,7 +8,6 @@ It constructs a logic program via `constructSolutionSpace` from the following in
 from collections import deque
 from collections.abc import (
     Callable,
-    Container,
     Generator,
     Hashable,
     Iterable,
@@ -36,6 +35,7 @@ from cosy.subtypes import Subtypes, Taxonomy
 from cosy.types import (
     Abstraction,
     Arrow,
+    Group,
     Implication,
     Intersection,
     LiteralParameter,
@@ -50,9 +50,6 @@ C = TypeVar("C", bound=Hashable)
 
 # type of component specifications
 Specification = Abstraction | Implication | Type
-
-# type of parameter space
-ParameterSpace = Mapping[str, Iterable | Container]
 
 
 @dataclass(frozen=True)
@@ -71,7 +68,7 @@ class MultiArrow:
 class CombinatorInfo:
     # container for auxiliary information about a combinator
     prefix: list[LiteralParameter | TermParameter | Predicate]
-    groups: dict[str, str]
+    groups: dict[str, Group]
     term_predicates: tuple[Callable[[dict[str, Any]], bool], ...]
     instantiations: deque[dict[str, Any]] | None
     type: list[list[MultiArrow]]
@@ -81,18 +78,15 @@ class Synthesizer(Generic[C]):
     def __init__(
         self,
         component_specifications: Mapping[C, Specification],
-        parameter_space: ParameterSpace | None = None,
         taxonomy: Taxonomy | None = None,
     ):
-        self.literals: ParameterSpace = {} if parameter_space is None else dict(parameter_space.items())
         self.repository: tuple[tuple[C, CombinatorInfo], ...] = tuple(
-            (c, Synthesizer._function_types(self.literals, ty)) for c, ty in component_specifications.items()
+            (c, Synthesizer._function_types(ty)) for c, ty in component_specifications.items()
         )
         self.subtypes = Subtypes(taxonomy if taxonomy is not None else {})
 
     @staticmethod
     def _function_types(
-        literals: ParameterSpace,
         parameterized_type: Specification,
     ) -> CombinatorInfo:
         """Presents a type as a list of 0-ary, 1-ary, ..., n-ary function types."""
@@ -108,7 +102,7 @@ class Synthesizer(Generic[C]):
 
         prefix: list[LiteralParameter | TermParameter | Predicate] = []
         variables: set[str] = set()
-        groups: dict[str, str] = {}
+        groups: dict[str, Group] = {}
         while not isinstance(parameterized_type, Type):
             if isinstance(parameterized_type, Abstraction):
                 param = parameterized_type.parameter
@@ -120,10 +114,6 @@ class Synthesizer(Generic[C]):
                 if isinstance(param, LiteralParameter):
                     prefix.append(param)
                     groups[param.name] = param.group
-                    # check if group is defined in the parameter space
-                    if param.group not in literals:
-                        msg = f"Group {param.group} is not defined in the parameter space."
-                        raise ValueError(msg)
                 elif isinstance(param, TermParameter):
                     prefix.append(param)
                     for free_var in param.group.free_vars:
@@ -182,25 +172,20 @@ class Synthesizer(Generic[C]):
                         if parameter.values is not None and value not in parameter.values(substitution):
                             # the inferred value is not in the set of values
                             continue
-                        if value not in self.literals[parameter.group]:
+                        if value not in parameter.group:
                             # the inferred value is not in the group
                             continue
                         stack.appendleft((substitution, index + 1, None))
                     elif parameter.values is not None:
                         stack.appendleft((substitution, index, iter(parameter.values(substitution))))
                     else:
-                        concrete_values = self.literals[parameter.group]
-                        if not isinstance(concrete_values, Iterable):
-                            msg = f"The value of {parameter.name} could not be inferred."
-                            raise RuntimeError(msg)
-                        else:
-                            stack.appendleft((substitution, index, iter(concrete_values)))
+                        stack.appendleft((substitution, index, iter(parameter.group)))
                 else:
                     try:
                         value = next(generator)
                     except StopIteration:
                         continue
-                    if value in self.literals[parameter.group]:
+                    if value in parameter.group:
                         stack.appendleft(({**substitution, parameter.name: value}, index + 1, None))
                     stack.appendleft((substitution, index, generator))
 
@@ -215,12 +200,11 @@ class Synthesizer(Generic[C]):
         self,
         nary_types: list[MultiArrow],
         paths: Iterable[Type],
-        groups: dict[str, str],
         substitution: dict[str, Any],
     ) -> Sequence[list[Type]]:
         # does the target of a multi-arrow contain a given type?
         def target_contains(m: MultiArrow, t: Type) -> bool:
-            return self.subtypes.check_subtype(m.target, t, groups, substitution)
+            return self.subtypes.check_subtype(m.target, t, substitution)
 
         # cover target using targets of multi-arrows in nary_types
         covers = minimal_covers(nary_types, paths, target_contains)
@@ -237,7 +221,7 @@ class Synthesizer(Generic[C]):
         def compare_args(args1, args2) -> bool:
             return all(
                 map(
-                    lambda a, b: self.subtypes.check_subtype(a, b, groups, substitution),
+                    lambda a, b: self.subtypes.check_subtype(a, b, substitution),
                     args1,
                     args2,
                 )
@@ -249,7 +233,6 @@ class Synthesizer(Generic[C]):
         self,
         paths: Iterable[Type],
         combinator_type: list[list[MultiArrow]],
-        groups: dict[str, str],
     ) -> dict[str, Any] | None:
         """
         Computes a substitution that needs to be part of every substitution S such that
@@ -266,7 +249,7 @@ class Synthesizer(Generic[C]):
 
             for nary_types in combinator_type:
                 for ty in nary_types:
-                    substitution = self.subtypes.infer_substitution(ty.target, path, groups)
+                    substitution = self.subtypes.infer_substitution(ty.target, path)
                     if substitution is None:
                         continue
                     if unique_substitution is None:
@@ -318,7 +301,6 @@ class Synthesizer(Generic[C]):
                         substitution = self._necessary_substitution(
                             current_target.organized,
                             combinator_info.type,
-                            combinator_info.groups,
                         )
 
                         # If there cannot be a suitable substitution, ignore this combinator
@@ -349,7 +331,6 @@ class Synthesizer(Generic[C]):
                             for subquery in self._subqueries(
                                 nary_types,
                                 current_target.organized,
-                                combinator_info.groups,
                                 instantiation,
                             ):
                                 if named_arguments is None:  # do this only once for each instantiation
@@ -357,15 +338,11 @@ class Synthesizer(Generic[C]):
                                         ConstantArgument(
                                             param.name,
                                             instantiation[param.name],
-                                            combinator_info.groups[param.name],
                                         )
                                         if isinstance(param, LiteralParameter)
                                         else NonTerminalArgument(
                                             param.name,
-                                            param.group.subst(
-                                                combinator_info.groups,
-                                                instantiation,
-                                            ),
+                                            param.group.subst(instantiation),
                                         )
                                         for param in combinator_info.prefix
                                         if isinstance(param, Parameter)
@@ -376,10 +353,10 @@ class Synthesizer(Generic[C]):
                                         if isinstance(argument, NonTerminalArgument)
                                     )
 
-                                anonymous_arguments: tuple[Argument, ...] = tuple(
+                                anonymous_arguments: tuple[NonTerminalArgument, ...] = tuple(
                                     NonTerminalArgument(
                                         None,
-                                        ty.subst(combinator_info.groups, instantiation),
+                                        ty.subst(instantiation),
                                     )
                                     for ty in subquery
                                 )

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -80,12 +80,13 @@ class Synthesizer(Generic[C]):
         taxonomy: Taxonomy | None = None,
     ):
         self.repository: tuple[tuple[C, CombinatorInfo], ...] = tuple(
-            (c, Synthesizer._function_types(ty)) for c, ty in component_specifications.items()
+            (c, Synthesizer._function_types(c, ty)) for c, ty in component_specifications.items()
         )
         self.subtypes = Subtypes(taxonomy if taxonomy is not None else {})
 
     @staticmethod
     def _function_types(
+        combinator: C,
         parameterized_type: Specification,
     ) -> CombinatorInfo:
         """Presents a type as a list of 0-ary, 1-ary, ..., n-ary function types."""
@@ -107,7 +108,7 @@ class Synthesizer(Generic[C]):
                 param = parameterized_type.parameter
                 if param.name in variables:
                     # check if parameter names are unique
-                    msg = f"Duplicate name: {param.name}"
+                    msg = f"Duplicate name {param.name} in specification of combinator {str(combinator)}."
                     raise ValueError(msg)
                 variables.add(param.name)
                 if isinstance(param, LiteralParameter):
@@ -118,7 +119,7 @@ class Synthesizer(Generic[C]):
                     for free_var in param.group.free_vars:
                         if free_var not in literal_variables:
                             # check if each parameter variable is abstracted
-                            msg = f"Parameter {free_var} is not abstracted."
+                            msg = f"Parameter {free_var} is not abstracted in specification of combinator {str(combinator)}."
                             raise ValueError(msg)
                 parameterized_type = parameterized_type.body
             elif isinstance(parameterized_type, Implication):
@@ -128,7 +129,7 @@ class Synthesizer(Generic[C]):
         for free_var in parameterized_type.free_vars:
             if free_var not in literal_variables:
                 # check if each parameter variable is abstracted
-                msg = f"Parameter {free_var} is not abstracted."
+                msg = f"Parameter {free_var} is not abstracted in specification of combinator {str(combinator)}."
                 raise ValueError(msg)
 
         current: list[MultiArrow] = [MultiArrow((), parameterized_type)]

--- a/src/cosy/synthesizer.py
+++ b/src/cosy/synthesizer.py
@@ -178,7 +178,12 @@ class Synthesizer(Generic[C]):
                     elif parameter.values is not None:
                         stack.appendleft((substitution, index, iter(parameter.values(substitution))))
                     else:
-                        stack.appendleft((substitution, index, iter(parameter.group)))
+                        try:
+                            # consider all individual values of a group
+                            stack.appendleft((substitution, index, iter(parameter.group)))
+                        except TypeError as e:
+                            msg = f"Group {parameter.group.name} is not iterable."
+                            raise ValueError(msg) from e
                 else:
                     try:
                         value = next(generator)

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -41,7 +41,7 @@ class Type(ABC):
         pass
 
     @abstractmethod
-    def subst(self, groups: Mapping[str, str], substitution: dict[str, Any]) -> Type:
+    def subst(self, substitution: dict[str, Any]) -> Type:
         pass
 
     @staticmethod
@@ -78,6 +78,22 @@ class Type(ABC):
 
 
 @dataclass(frozen=True)
+class Group:
+    name: str = field(init=False)
+
+    def __iter__(self):
+        # enumeration logic
+        pass
+
+    def __contains__(self, x):
+        # default membership logic
+        return x in self.__iter__()
+
+    def __str__(self) -> str:
+        return f"{self.name}"
+
+
+@dataclass(frozen=True)
 class Omega(Type):
     is_omega: bool = field(init=False, compare=False)
     size: int = field(init=False, compare=False)
@@ -107,7 +123,7 @@ class Omega(Type):
     def _free_vars(self) -> set[str]:
         return set()
 
-    def subst(self, _groups: Mapping[str, str], _substitution: dict[str, Any]) -> Type:
+    def subst(self, _substitution: dict[str, Any]) -> Type:
         return self
 
 
@@ -147,10 +163,10 @@ class Constructor(Type):
             return str(self.name)
         return f"{self.name!s}({self.arg!s})"
 
-    def subst(self, groups: Mapping[str, str], substitution: dict[str, Any]) -> Type:
+    def subst(self, substitution: dict[str, Any]) -> Type:
         if not any(var in substitution for var in self.free_vars):
             return self
-        return Constructor(self.name, self.arg.subst(groups, substitution))
+        return Constructor(self.name, self.arg.subst(substitution))
 
 
 @dataclass(frozen=True)
@@ -189,12 +205,12 @@ class Arrow(Type):
     def __str__(self) -> str:
         return f"{self.source} -> {self.target}"
 
-    def subst(self, groups: Mapping[str, str], substitution: dict[str, Any]) -> Type:
+    def subst(self, substitution: dict[str, Any]) -> Type:
         if not any(var in substitution for var in self.free_vars):
             return self
         return Arrow(
-            self.source.subst(groups, substitution),
-            self.target.subst(groups, substitution),
+            self.source.subst(substitution),
+            self.target.subst(substitution),
         )
 
 
@@ -230,19 +246,18 @@ class Intersection(Type):
     def __str__(self) -> str:
         return f"{self.left} & {self.right}"
 
-    def subst(self, groups: Mapping[str, str], substitution: dict[str, Any]) -> Type:
+    def subst(self, substitution: dict[str, Any]) -> Type:
         if not any(var in substitution for var in self.free_vars):
             return self
         return Intersection(
-            self.left.subst(groups, substitution),
-            self.right.subst(groups, substitution),
+            self.left.subst(substitution),
+            self.right.subst(substitution),
         )
 
 
 @dataclass(frozen=True)
 class Literal(Type):
     value: Any  # has to be Hashable
-    group: str
     is_omega: bool = field(init=False, compare=False)
     size: int = field(init=False, compare=False)
     organized: set[Type] = field(init=False, compare=False)
@@ -269,9 +284,9 @@ class Literal(Type):
         return set()
 
     def __str__(self) -> str:
-        return f"[{self.value!s}, {self.group}]"
+        return f"[{self.value!s}]"
 
-    def subst(self, _groups: Mapping[str, str], _substitution: dict[str, Any]) -> Type:
+    def subst(self, _substitution: dict[str, Any]) -> Type:
         return self
 
 
@@ -306,9 +321,9 @@ class Var(Type):
     def __str__(self) -> str:
         return f"<{self.name!s}>"
 
-    def subst(self, groups: Mapping[str, str], substitution: dict[str, Any]) -> Type:
+    def subst(self, substitution: dict[str, Any]) -> Type:
         if self.name in substitution:
-            return Literal(substitution[self.name], groups[self.name])
+            return Literal(substitution[self.name])
         return self
 
 
@@ -317,7 +332,7 @@ class Parameter(ABC):
     """Abstract base class for parameter specification."""
 
     name: str
-    group: str | Type
+    group: Group | Type
 
     def __str__(self) -> str:
         return f"<{self.name}, {self.group}>"
@@ -327,7 +342,7 @@ class Parameter(ABC):
 class LiteralParameter(Parameter):
     """Specification of a literal parameter."""
 
-    group: str
+    group: Group
     #  Specification of literal assignment from a collection
     values: Callable[[dict[str, Any]], Sequence[Any]] | None = field(default=None)
 

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -97,12 +97,8 @@ class Group(ABC):
 class DataGroup(Group):
     # Group definition based on given data (e.g. a list, range, set, ...)
     def __init__(self, name: str, data: Any):
+        self.name = name
         self._data = data
-        self._name = name
-
-    @property
-    def name(self) -> str:
-        return self._name
 
     def __iter__(self):
         return iter(self._data)

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -79,11 +79,9 @@ class Type(ABC):
 
 @dataclass(frozen=True)
 class Group(ABC):
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Human-readable name of the group."""
+    name: str = field(init=False)
 
+    @abstractmethod
     def __iter__(self):
         # enumeration logic
         pass

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -86,6 +86,7 @@ class Group(ABC):
         # enumeration logic
         pass
 
+    @abstractmethod
     def __contains__(self, x):
         # default membership logic
         return x in self.__iter__()

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -78,8 +78,11 @@ class Type(ABC):
 
 
 @dataclass(frozen=True)
-class Group:
-    name: str = field(init=False)
+class Group(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name of the group."""
 
     def __iter__(self):
         # enumeration logic
@@ -91,6 +94,23 @@ class Group:
 
     def __str__(self) -> str:
         return f"{self.name}"
+
+
+class DataGroup(Group):
+    # Group definition based on given data (e.g. a list, range, set, ...)
+    def __init__(self, name: str, data: Any):
+        self._data = data
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __contains__(self, x):
+        return x in self._data
 
 
 @dataclass(frozen=True)

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -96,7 +96,7 @@ class Group(ABC):
 
 class DataGroup(Group):
     # Group definition based on given data (e.g. a list, range, set, ...)
-    def __init__(self, name: str, data: Any):
+    def __init__(self, name: str, data: Iterable):
         self.name = name
         self._data = data
 

--- a/src/cosy/types.py
+++ b/src/cosy/types.py
@@ -77,7 +77,6 @@ class Type(ABC):
         return Constructor(name, self)
 
 
-@dataclass(frozen=True)
 class Group(ABC):
     name: str = field(init=False)
 

--- a/tests/test_contains_tree.py
+++ b/tests/test_contains_tree.py
@@ -5,7 +5,7 @@ import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree
-from cosy.types import Group, Literal, Var
+from cosy.types import DataGroup, Literal, Var
 
 
 def leaf() -> str:
@@ -16,21 +16,14 @@ def branch(depth: int, _new_depth: int, left: str, right: str) -> str:
     return f"(B {depth} {left} {right})"
 
 
-class Int(Group):
-    name = "int"
-
-    def __iter__(self):
-        yield from [0, 1, 2, 3]
-
-
 @pytest.fixture
 def component_specifications():
     return {
         # recursive unproductive specification
         leaf: DSL().suffix(Literal(0)),
         branch: DSL()
-        .parameter("depth", Int())
-        .parameter("new_depth", Int(), lambda vs: [vs["depth"] - 1])
+        .parameter("depth", DataGroup("int", [0, 1, 2, 3]))
+        .parameter("new_depth", DataGroup("int", [0, 1, 2, 3]), lambda vs: [vs["depth"] - 1])
         .argument("left", Var("new_depth"))
         .argument("right", Var("new_depth"))
         .constraint(lambda vs: vs["left"] == vs["right"])

--- a/tests/test_contains_tree.py
+++ b/tests/test_contains_tree.py
@@ -5,7 +5,7 @@ import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree
-from cosy.types import Literal, Var
+from cosy.types import Group, Literal, Var
 
 
 def leaf() -> str:
@@ -16,14 +16,21 @@ def branch(depth: int, _new_depth: int, left: str, right: str) -> str:
     return f"(B {depth} {left} {right})"
 
 
+class Int(Group):
+    name = "int"
+
+    def __iter__(self):
+        yield from [0, 1, 2, 3]
+
+
 @pytest.fixture
 def component_specifications():
     return {
         # recursive unproductive specification
-        leaf: DSL().suffix(Literal(0, "int")),
+        leaf: DSL().suffix(Literal(0)),
         branch: DSL()
-        .parameter("depth", "int")
-        .parameter("new_depth", "int", lambda vs: [vs["depth"] - 1])
+        .parameter("depth", Int())
+        .parameter("new_depth", Int(), lambda vs: [vs["depth"] - 1])
         .argument("left", Var("new_depth"))
         .argument("right", Var("new_depth"))
         .constraint(lambda vs: vs["left"] == vs["right"])
@@ -33,15 +40,14 @@ def component_specifications():
 
 @pytest.fixture
 def query():
-    return Literal(2, "int")
+    return Literal(2)
 
 
 T = int | Callable
 
 
 def test_contains_tree(query, component_specifications) -> None:
-    parameter_space = {"int": [0, 1, 2, 3]}
-    solution_space = Synthesizer(component_specifications, parameter_space).construct_solution_space(query)
+    solution_space = Synthesizer(component_specifications).construct_solution_space(query)
 
     tree_correct = Tree[T](
         branch,

--- a/tests/test_group_underspecification.py
+++ b/tests/test_group_underspecification.py
@@ -1,0 +1,32 @@
+# test for missing iter implementation in a Group subclass
+
+import pytest
+from cosy.dsl import DSL
+from cosy.synthesizer import Synthesizer
+from cosy.types import Constructor, Group
+
+
+def test_infinite_enumeration() -> None:
+    def c(x) -> str:
+        return f"(C {x})"
+
+    # group with missing iter method
+    class Contains(Group):
+        name = "contains"
+
+        def __iter__(self):
+            pass
+
+        def __contains__(self, _value: object) -> bool:
+            return True
+
+    component_specifications = {
+        c: DSL().parameter("x", Contains()).suffix(Constructor("c")),
+    }
+
+    synthesizer = Synthesizer(component_specifications)
+    target = Constructor("c")
+
+    with pytest.raises(ValueError, match="Group contains is not iterable."):
+        # iter is necessary to determine the value of the literal variable x
+        synthesizer.construct_solution_space(target)

--- a/tests/test_infinite_enumeration.py
+++ b/tests/test_infinite_enumeration.py
@@ -1,13 +1,13 @@
 # test of the DSL for non-inferrable infinite parameter spaces
 
-from collections.abc import Container, Iterable, Iterator
+from collections.abc import Iterator
 
 import pytest
 from cosy.dsl import DSL
 from cosy.solution_space import SolutionSpace
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree
-from cosy.types import Constructor, Var
+from cosy.types import Constructor, Group, Var
 
 
 def test_infinite_enumeration() -> None:
@@ -24,20 +24,10 @@ def test_infinite_enumeration() -> None:
     def f() -> str:
         return "F"
 
-    component_specifications = {
-        c: DSL()
-        .parameter("x", "nat")
-        .parameter("y", "nat")
-        .argument("t1", Var("x"))
-        .argument("t2", Var("y"))
-        .suffix(Constructor("a") ** Constructor("a")),
-        d: DSL().parameter("x", "nat").suffix(Var("x")),
-        e: DSL().parameter("y", "nat").suffix(Var("y")),
-        f: DSL().suffix(Constructor("a")),
-    }
-
     # infinite enumeration of natural numbers
-    class Nat(Iterable[int], Container):
+    class Nat(Group):
+        name = "nat"
+
         def __iter__(self) -> Iterator[int]:
             i: int = 0
             while True:
@@ -47,8 +37,19 @@ def test_infinite_enumeration() -> None:
         def __contains__(self, value: object) -> bool:
             return isinstance(value, int) and value >= 0
 
-    parameter_space = {"nat": Nat()}
-    synthesizer = Synthesizer(component_specifications, parameter_space)
+    component_specifications = {
+        c: DSL()
+        .parameter("x", Nat())
+        .parameter("y", Nat())
+        .argument("t1", Var("x"))
+        .argument("t2", Var("y"))
+        .suffix(Constructor("a") ** Constructor("a")),
+        d: DSL().parameter("x", Nat()).suffix(Var("x")),
+        e: DSL().parameter("y", Nat()).suffix(Var("y")),
+        f: DSL().suffix(Constructor("a")),
+    }
+
+    synthesizer = Synthesizer(component_specifications)
     target = Constructor("a")
 
     # intermediate solution space

--- a/tests/test_literal_candidates.py
+++ b/tests/test_literal_candidates.py
@@ -14,6 +14,9 @@ def test_candidates() -> None:
     class Bool(Group):
         name = "bool"
 
+        def __contains__(self, x):
+            return super().__contains__(x)
+
         def __iter__(self):
             yield from [True, False]
 
@@ -55,6 +58,9 @@ def test_multi_values1() -> None:
     class Int(Group):
         name = "int"
 
+        def __contains__(self, x):
+            return super().__contains__(x)
+
         def __iter__(self):
             yield from [0, 1, 2, 3]
 
@@ -78,6 +84,9 @@ def test_multi_values2() -> None:
 
     class Int(Group):
         name = "int"
+
+        def __contains__(self, x):
+            return super().__contains__(x)
 
         def __iter__(self):
             yield from [0, 1, 2, 3]

--- a/tests/test_literal_candidates.py
+++ b/tests/test_literal_candidates.py
@@ -1,10 +1,9 @@
 # test for candidate generation for assigning values to literal variables
 
-from collections.abc import Container
 
 from cosy.dsl import DSL
 from cosy.synthesizer import Synthesizer
-from cosy.types import Constructor, Literal, Omega, Type, Var
+from cosy.types import Constructor, Group, Literal, Omega, Type, Var
 
 
 def test_candidates() -> None:
@@ -12,24 +11,29 @@ def test_candidates() -> None:
     def c(x: bool, y: bool, z: bool) -> str:
         return f"C {x} {y} {z}"
 
+    class Bool(Group):
+        name = "bool"
+
+        def __iter__(self):
+            yield from [True, False]
+
     component_specifications = {
         c: DSL()
-        .parameter("x", "bool")
+        .parameter("x", Bool())
         .parameter_constraint(lambda vs: vs["x"])  # x is True
-        .parameter("y", "bool", lambda _vs: [False])  # y is False
-        .parameter("z", "bool", lambda vs: [vs["x"]])  # z is equal to x
+        .parameter("y", Bool(), lambda _vs: [False])  # y is False
+        .parameter("z", Bool(), lambda vs: [vs["x"]])  # z is equal to x
         .suffix(Constructor("a", Var("x")) & Constructor("b", Var("y")) & Constructor("c", Var("z")))
     }
 
     def xyz(x: bool | None, y: bool | None, z: bool | None) -> Type:
         return (
-            Constructor("a", Omega() if x is None else Literal(x, "bool"))
-            & Constructor("b", Omega() if y is None else Literal(y, "bool"))
-            & Constructor("c", Omega() if z is None else Literal(z, "bool"))
+            Constructor("a", Omega() if x is None else Literal(x))
+            & Constructor("b", Omega() if y is None else Literal(y))
+            & Constructor("c", Omega() if z is None else Literal(z))
         )
 
-    parameter_space = {"bool": [True, False]}
-    synthesizer = Synthesizer(component_specifications, parameter_space)
+    synthesizer = Synthesizer(component_specifications)
 
     for x in [True, False, None]:
         for y in [True, False, None]:
@@ -48,16 +52,21 @@ def test_multi_values1() -> None:
     def c(a: int, b: int) -> str:
         return f"C {a} {b}"
 
-    parameter_space = {"int": [0, 1, 2, 3]}
+    class Int(Group):
+        name = "int"
+
+        def __iter__(self):
+            yield from [0, 1, 2, 3]
+
     component_specifications = {
         c: DSL()
-        .parameter("a", "int")  # a in [0, 1, 2, 3]
-        .parameter("b", "int", lambda vs: [vs["a"] - 1, vs["a"] + 1])  # b in [a-1, a+1]
+        .parameter("a", Int())  # a in [0, 1, 2, 3]
+        .parameter("b", Int(), lambda vs: [vs["a"] - 1, vs["a"] + 1])  # b in [a-1, a+1]
         .suffix(Constructor("c", Var("a")))
     }
 
-    synthesizer = Synthesizer(component_specifications, parameter_space)
-    target = Constructor("c", Literal(0, "int"))
+    synthesizer = Synthesizer(component_specifications)
+    target = Constructor("c", Literal(0))
     solution_space = synthesizer.construct_solution_space(target)
     assert [tree.interpret() for tree in solution_space.enumerate_trees(target)] == ["C 0 1"]
 
@@ -67,16 +76,21 @@ def test_multi_values2() -> None:
     def c(a: int, b: int) -> str:
         return f"C {a} {b}"
 
-    parameter_space = {"int": [0, 1, 2, 3]}
+    class Int(Group):
+        name = "int"
+
+        def __iter__(self):
+            yield from [0, 1, 2, 3]
+
     component_specifications = {
         c: DSL()
-        .parameter("a", "int")
-        .parameter("b", "int", lambda vs: [vs["a"] - 1, vs["a"] + 1])
+        .parameter("a", Int())
+        .parameter("b", Int(), lambda vs: [vs["a"] - 1, vs["a"] + 1])
         .suffix(Constructor("c", Var("a")))
     }
 
-    synthesizer = Synthesizer(component_specifications, parameter_space)
-    target = Constructor("c", Literal(1, "int"))
+    synthesizer = Synthesizer(component_specifications)
+    target = Constructor("c", Literal(1))
     solution_space = synthesizer.construct_solution_space(target)
     assert {tree.interpret() for tree in solution_space.enumerate_trees(target)} == {
         "C 1 2",
@@ -86,7 +100,7 @@ def test_multi_values2() -> None:
 
 def test_infinite_values() -> None:
     # the number of values for a literal variable can be infinite
-    class Nat(Container):
+    class Nat(Group):
         # represents the set of (arbitrary large) natural numbers
         def __contains__(self, value: object) -> bool:
             return isinstance(value, int) and value >= 0
@@ -94,18 +108,17 @@ def test_infinite_values() -> None:
     def c(x: int, _y: int, b: str) -> str:
         return f"C {x} ({b})"
 
-    parameter_space = {"nat": Nat()}
-    target = "c" @ Literal(3, "nat")
+    target = "c" @ Literal(3)
 
     component_specifications = {
         c: DSL()
-        .parameter("a", "nat")  # a in [0, 1, 2, ...]
-        .parameter("b", "nat", lambda vs: [vs["a"] - 1])  # b in [a-1]
+        .parameter("a", Nat())  # a in [0, 1, 2, ...]
+        .parameter("b", Nat(), lambda vs: [vs["a"] - 1])  # b in [a-1]
         .suffix(("c" @ Var("b")) ** ("c" @ Var("a"))),  # c(b) -> c(a)
-        "ZERO": "c" @ Literal(0, "nat"),  # c(0)
+        "ZERO": "c" @ Literal(0),  # c(0)
     }
 
-    synthesizer = Synthesizer(component_specifications, parameter_space)
+    synthesizer = Synthesizer(component_specifications)
     solution_space = synthesizer.construct_solution_space(target)
 
     assert [tree.interpret() for tree in solution_space.enumerate_trees(target)] == ["C 3 (C 2 (C 1 (ZERO)))"]

--- a/tests/test_literal_candidates.py
+++ b/tests/test_literal_candidates.py
@@ -107,6 +107,9 @@ def test_infinite_values() -> None:
         def __contains__(self, value: object) -> bool:
             return isinstance(value, int) and value >= 0
 
+        def __iter__(self):
+            pass
+
     def c(x: int, _y: int, b: str) -> str:
         return f"C {x} ({b})"
 

--- a/tests/test_literal_candidates.py
+++ b/tests/test_literal_candidates.py
@@ -101,6 +101,8 @@ def test_multi_values2() -> None:
 def test_infinite_values() -> None:
     # the number of values for a literal variable can be infinite
     class Nat(Group):
+        name = "nat"
+
         # represents the set of (arbitrary large) natural numbers
         def __contains__(self, value: object) -> bool:
             return isinstance(value, int) and value >= 0

--- a/tests/test_literal_inference.py
+++ b/tests/test_literal_inference.py
@@ -1,0 +1,94 @@
+# test for corrrect literal inference in the presence of multiple parameters
+
+import pytest
+from cosy.dsl import DSL
+from cosy.synthesizer import Synthesizer
+from cosy.tree import Tree
+from cosy.types import Arrow, Constructor, Group, Intersection, Literal, Var
+
+
+def leaf_nat(x: int) -> str:
+    return str(x)
+
+
+def leaf_bools(y: tuple[bool]) -> str:
+    return str(y)
+
+
+def node(_x: int, _y: tuple[bool], argument: str) -> str:
+    return f"(Node {argument})"
+
+
+@pytest.fixture
+def component_specifications():
+    class Nat(Group):
+        name = "nat"
+
+        def __contains__(self, x):
+            return x is None or (isinstance(x, int) and x >= 0)
+
+        def __iter__(self):
+            yield None  # default value, do not enumerate all natural numbers
+
+    class Bools(Group):
+        name = "bools"
+
+        def __contains__(self, x):
+            return x is None or (isinstance(x, tuple) and all(isinstance(b, bool) for b in x))
+
+        def __iter__(self):
+            yield None  # default value, do not enumerate all boolean tuples
+
+    return {
+        leaf_nat: DSL().parameter("x", Nat()).suffix(Constructor("a", Var("x"))),
+        leaf_bools: DSL().parameter("y", Bools()).suffix(Constructor("b", Var("y"))),
+        node: DSL()
+        .parameter("x", Nat())
+        .parameter("y", Bools())
+        .suffix(
+            Intersection(
+                Arrow(Constructor("a", Var("x")), Constructor("p", Var("x"))),
+                Arrow(Constructor("b", Var("y")), Constructor("q", Var("y"))),
+            )
+        ),
+    }
+
+
+@pytest.fixture
+def query_nat():
+    return Constructor("p", Literal(100))
+
+
+@pytest.fixture
+def query_bools():
+    return Constructor("q", Literal((True, True, False, True)))
+
+
+def test_literal_inference_nat(query_nat, component_specifications) -> None:
+    solution_space = Synthesizer(component_specifications).construct_solution_space(query_nat)
+
+    result = Tree(
+        node,
+        [
+            Tree(100),
+            Tree(None),
+            Tree(leaf_nat, [Tree(100)]),
+        ],
+    )
+
+    assert solution_space.contains_tree(query_nat, result)
+
+
+def test_literal_inference_bools(query_bools, component_specifications) -> None:
+    solution_space = Synthesizer(component_specifications).construct_solution_space(query_bools)
+
+    result = Tree(
+        node,
+        [
+            Tree(None),
+            Tree((True, True, False, True)),
+            Tree(leaf_bools, [Tree((True, True, False, True))]),
+        ],
+    )
+
+    assert solution_space.contains_tree(query_bools, result)

--- a/tests/test_literal_inference.py
+++ b/tests/test_literal_inference.py
@@ -1,11 +1,11 @@
 # test for corrrect literal inference in the presence of multiple parameters
 
+from collections.abc import Callable
 import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree
 from cosy.types import Arrow, Constructor, Group, Intersection, Literal, Var
-
 
 def leaf_nat(x: int) -> str:
     return str(x)
@@ -63,16 +63,17 @@ def query_nat():
 def query_bools():
     return Constructor("q", Literal((True, True, False, True)))
 
+T = int | Callable | None | tuple
 
 def test_literal_inference_nat(query_nat, component_specifications) -> None:
     solution_space = Synthesizer(component_specifications).construct_solution_space(query_nat)
 
-    result = Tree(
+    result = Tree[T](
         node,
         [
-            Tree(100),
-            Tree(None),
-            Tree(leaf_nat, [Tree(100)]),
+            Tree[T](100),
+            Tree[T](None),
+            Tree[T](leaf_nat, [Tree[T](100)]),
         ],
     )
 
@@ -82,12 +83,12 @@ def test_literal_inference_nat(query_nat, component_specifications) -> None:
 def test_literal_inference_bools(query_bools, component_specifications) -> None:
     solution_space = Synthesizer(component_specifications).construct_solution_space(query_bools)
 
-    result = Tree(
+    result = Tree[T](
         node,
         [
-            Tree(None),
-            Tree((True, True, False, True)),
-            Tree(leaf_bools, [Tree((True, True, False, True))]),
+            Tree[T](None),
+            Tree[T]((True, True, False, True)),
+            Tree[T](leaf_bools, [Tree[T]((True, True, False, True))]),
         ],
     )
 

--- a/tests/test_literal_inference.py
+++ b/tests/test_literal_inference.py
@@ -1,11 +1,13 @@
 # test for corrrect literal inference in the presence of multiple parameters
 
 from collections.abc import Callable
+
 import pytest
 from cosy.dsl import DSL
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree
 from cosy.types import Arrow, Constructor, Group, Intersection, Literal, Var
+
 
 def leaf_nat(x: int) -> str:
     return str(x)
@@ -63,7 +65,9 @@ def query_nat():
 def query_bools():
     return Constructor("q", Literal((True, True, False, True)))
 
+
 T = int | Callable | None | tuple
+
 
 def test_literal_inference_nat(query_nat, component_specifications) -> None:
     solution_space = Synthesizer(component_specifications).construct_solution_space(query_nat)


### PR DESCRIPTION
- removed `group` from Literal
- removed `parameter_space` in favor of the `Group` class
- updated all tests and examples

Both changes lead to simpler and faster code with less `string` indirection.