### PR TITLE
Wrap component specifications in named tuples (Closes #18)

### DIFF
--- a/docs/features/constraints.md
+++ b/docs/features/constraints.md
@@ -18,18 +18,32 @@ def zero(s: str) -> str:
 def one(s: str) -> str:
     return s + "1"
 ```
-with the following specifications: 
+These binary sequences are assigned names and specifications, forming a triple: 
 ```
-empty: SpecificationBuilder().suffix(Constructor("str")),
-
-zero: SpecificationBuilder()
+(  #
+    "empty",
+    empty,
+    SpecificationBuilder()
+    .suffix(Constructor("str")),
+),
+(  #
+    "zero",
+    zero,
+    SpecificationBuilder()
     .argument("s", Constructor("str"))
     .suffix(Constructor("str")),
-
-one: SpecificationBuilder()
+),
+(  #
+    "one",
+    one,
+    SpecificationBuilder()
     .argument("s", Constructor("str"))
     .suffix(Constructor("str")),
+),
+
 ```
+The binary sequences act as interpretation of the assigned names, meaning that terms consist of `"zero"` and `"one"`, 
+but their interpretations are `"0"` and `"1"`.
 
 Then, we specify when such sequences match a given regular expression using a `constraint`.
 The component `fin` does not change a given sequence `s`.
@@ -40,29 +54,41 @@ This exposes a computed property (corresponding regular expression) as a nominal
 def fin(_b: bool, s: str) -> str:
     return s
 ```
-with specification: 
-``` hl_lines="4"
-fin: SpecificationBuilder()
-    .parameter("r", "regular_expression")
+with triple: 
+```
+(  #
+    "fin",
+    fin,
+    SpecificationBuilder()
+    .parameter("r", RegularExpression())
     .argument("s", Constructor("str"))
-    .constraint(lambda vs: re.fullmatch(vs["r"], vs["s"].interpret())) # (1)!
+    .constraint(lambda vs: bool(re.fullmatch(vs["r"], vs["s"])))
     .suffix(Constructor("matches", Var("r"))),
+),
 ```
 
-1. A parameter constraint is used to ensure that `s` matches the regular expression `r`. 
+A parameter constraint is used to ensure that `s` matches the regular expression `r`. 
+The parameter `r` is an arbitrary value from a given Group of values. These groups can be members of an Iterable, 
+but may also define custom logic for membership. 
 
-In the body of the constraint, parameters are given as their values and arguments are given as their tree representation, which can be interpreted.
-Therefore, the value of the parameter `r` is `vs["r"]`.
-The interpreted value of the argument `s` is `vs["s"].interpret()`
+In the body of the constraint, parameters and arguments are given as their values and their interpretation, respectively. 
+Therefore:
+ - The value of the parameter `r` is `vs["r"]`, a string describing a regex.
+ - The interpreted value of the argument `s` is `vs["s"]`, 
+   a string representing the current term consisting of `"0"`s and `"1"`s (its interpretation). 
 
 Using the above specifications, we can construct sequences that match the specified regular expressions:
 ```
-class RegularExpression(Container): # (1)!
-    def __contains__(self, value: object) -> bool:
-        return isinstance(value, str)
+    class RegularExpression(Group): # (1)!
+        name = "regex"
 
-parameter_space = {"regular_expression": RegularExpression()}
-cosy = CoSy(component_specifications, parameter_space) # (2)!
+        def __contains__(self, value: object) -> bool:
+            return isinstance(value, str)
+
+        def __iter__(self):
+            pass
+
+cosy = CoSy(component_specifications) # (2)!
 query: Type = Constructor("matches", Literal("01+0")) # (3)!
  
 for solution in cosy.solve(query): # (4)!
@@ -74,7 +100,7 @@ for solution in cosy.solve(query): # (4)!
 3. A Query for sequences matching the regular expression "01+0"
 4. Solve the query and print all solutions. 
 
-The above results in: `010`, `0110`, `01110`, `011110`, ...
+The above results in: `"010"`, `"0110"`, `"01110"`, `"011110"`, ...
 
 ### Remarks
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,13 +4,13 @@ The toy example shows the computation of Fibonacci numbers by means of compositi
 
 ## 1. Define Component Specifications
 
-Using domain-specific language provided by the `SpecificationBuilder` class define a mapping of components to respective specifications.
+Using domain-specific language provided by the `SpecificationBuilder` class define a triple of named components and respective specifications `(name, interpretation, specification)`.
 
 - The component `fib_zero` is specified by `Constructor("fib") & Constructor("at", Literal(0, "int"))`, which combines two properties.
   + `Constructor("fib")` means that `fib_zero` it is a Fibonacci number.
   + `Constructor("at", Literal(0))` means that `fib_zero` is associated with index `0`.
 - The component `fib_one`, similarly to `fib_zero`, is a Fibonacci number and is associated with index `1`.
-- The component `fib_next` has three parameters associated with the group `int`
+- The component `fib_next` has three parameters associated with the DataGroup `int`. In the toy example, indices less than `20` are considered.
   + `z` index of the constructed Fibonacci number
   + `y` index of the previous Fibonacci number, which is `z - 1`
   + `x` index of the Fibonacci number two indices prior, which is `z - 2`
@@ -31,46 +31,45 @@ def fib_one() -> int:
 def fib_next(_z: int, _y: int, _x: int, f1 : int, f2: int) -> int:
     return f1 + f2
 
-component_specifications = {
-    fib_zero: SpecificationBuilder()
-          .suffix(Constructor("fib") & Constructor("at", Literal(0))),
-
-    fib_one: SpecificationBuilder()
-          .suffix(Constructor("fib") & Constructor("at", Literal(1))),
-
-    fib_next: SpecificationBuilder()
-              .parameter("z", "int")
-              .parameter("y", "int", lambda vs: [vs["z"] - 1])
-              .parameter("x", "int", lambda vs: [vs["z"] - 2])
-              .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
-              .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
-              .suffix(Constructor("fib") & Constructor("at", Var("z"))),
-}
+named_components_with_specifications = [
+        (  #
+            "fib_zero",
+            fib_zero,
+            SpecificationBuilder()
+            .suffix(Constructor("fib") & Constructor("at", Literal(0))),
+        ),
+        (  #
+            "fib_one",
+            fib_one,
+            SpecificationBuilder()
+            .suffix(Constructor("fib") & Constructor("at", Literal(1))),
+        ),
+        (  #
+            "fib_next",
+            fib_next,
+            SpecificationBuilder()
+            .parameter("z", DataGroup("int", range(bound)))
+            .parameter("y", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 1])
+            .parameter("x", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 2])
+            .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
+            .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
+            .suffix(Constructor("fib") & Constructor("at", Var("z"))),
+        ),
+    ]
 ```
 
-## 2. Define Parameter Space
+## 2. Instantiate CoSy
 
-Define a mapping from parameter groups to parameter values.
-In the toy example, indices less than `20` are considered.
-
-```
-parameter_space = {
-    "int": list(range(0, 20))
-}
-```
-
-## 3. Instantiate CoSy
-
-Create an instance of `CoSy` by providing component specifications and the parameter space.
+Create an instance of `CoSy` by providing the named component with their specifications.
 
 ```
-cosy = CoSy(component_specifications, parameter_space)
+cosy = CoSy(component_specifications)
 ```
 
-## 4. Specify a Query and Construct Solutions
+## 3. Specify a Query and Construct Solutions
 
 Specify the query for which solutions should be found.
-Solutions are found by means of instantiation and composition of the given components in the given parameter space.
+Solutions are found by means of instantiation and composition of the given components in the given parameter space ().
 
 ### Arbitrary Fibonacci numbers
 

--- a/examples/example_constraints.py
+++ b/examples/example_constraints.py
@@ -63,17 +63,32 @@ def main():
         def __iter__(self):
             pass
 
-    component_specifications = {
-        empty: SpecificationBuilder().suffix(Constructor("str")),
-        zero: SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
-        one: SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
-        fin: SpecificationBuilder()
-        .parameter("r", RegularExpression())
-        .argument("s", Constructor("str"))
-        # parameter constraint to ensure that s matches the regular expression r
-        .constraint(lambda vs: re.fullmatch(vs["r"], vs["s"].interpret()))
-        .suffix(Constructor("matches", Var("r"))),
-    }
+    component_specifications = [
+        (  #
+            "empty",
+            empty,
+            SpecificationBuilder().suffix(Constructor("str")),
+        ),
+        (  #
+            "zero",
+            zero,
+            SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
+        ),
+        (  #
+            "one",
+            one,
+            SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
+        ),
+        (  #
+            "fin",
+            fin,
+            SpecificationBuilder()
+            .parameter("r", RegularExpression())
+            .argument("s", Constructor("str"))
+            .constraint(lambda vs: re.fullmatch(vs["r"], vs["s"]))
+            .suffix(Constructor("matches", Var("r"))),
+        ),
+    ]
 
     # CoSy instance with the component specifications and parameter space
     cosy = CoSy(component_specifications)

--- a/examples/example_constraints_inline.py
+++ b/examples/example_constraints_inline.py
@@ -1,6 +1,6 @@
-##Constraints##
+##Constraints with Inlined Interpretations##
 """
-Demonstrates constraints in CoSy.
+Demonstrates constraints in CoSy, highlighting how the Component class can be used to inline the interpretation.
 """
 
 import re
@@ -8,48 +8,6 @@ import re
 from cosy import CoSy
 from cosy.specification_builder import SpecificationBuilder
 from cosy.types import Constructor, Group, Literal, Type, Var
-
-
-def empty() -> str:
-    """
-    Return an empty string.
-
-    :return: An empty string.
-    """
-    return ""
-
-
-def zero(s: str) -> str:
-    """
-    Append the string "0" to the input string.
-
-    :param s: The input string to which "0" will be appended.
-    :return: The input string with "0" appended.
-    """
-    return s + "0"
-
-
-def one(s: str) -> str:
-    """
-    Append the string "1" to the input string.
-
-    :param s: The input string to which "1" will be appended.
-    :return: The input string with "1" appended.
-    """
-    return s + "1"
-
-
-def fin(_r: str, s: str) -> str:
-    """
-    Return the input string. The input regular expression is not used in this function as it does not contribute to
-    the resulting string interpretation of synthesized results. However, it can not be omitted, as the type of the
-    combinator specifies its presence.
-
-    :param _r: The input regular expression.
-    :param s: The input string.
-    :return: The unmodified input string.
-    """
-    return s
 
 
 def main():
@@ -66,22 +24,22 @@ def main():
     named_components_with_specifications = [
         (  #
             "empty",
-            empty,
+            lambda: "",
             SpecificationBuilder().suffix(Constructor("str")),
         ),
         (  #
             "zero",
-            zero,
+            lambda s: s + "0",
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
         (  #
             "one",
-            one,
+            lambda s: s + "1",
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
         (  #
             "fin",
-            fin,
+            lambda _, s: s,
             SpecificationBuilder()
             .parameter("r", RegularExpression())
             .argument("s", Constructor("str"))

--- a/examples/example_fibonacci.py
+++ b/examples/example_fibonacci.py
@@ -45,20 +45,32 @@ def main():
     # range of relevant indices for Fibonacci numbers
     bound = 20
 
-    component_specifications = {
-        fib_zero: SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(0))),
-        fib_one: SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(1))),
-        fib_next: SpecificationBuilder()
-        .parameter("z", DataGroup("int", range(bound)))
-        .parameter("y", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 1])
-        .parameter("x", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 2])
-        .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
-        .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
-        .suffix(Constructor("fib") & Constructor("at", Var("z"))),
-    }
+    named_components_with_specifications = [
+        (  #
+            "fib_zero",
+            fib_zero,
+            SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(0))),
+        ),
+        (  #
+            "fib_one",
+            fib_one,
+            SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(1))),
+        ),
+        (  #
+            "fib_next",
+            fib_next,
+            SpecificationBuilder()
+            .parameter("z", DataGroup("int", range(bound)))
+            .parameter("y", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 1])
+            .parameter("x", DataGroup("int", range(bound)), lambda vs: [vs["z"] - 2])
+            .argument("f1", Constructor("fib") & Constructor("at", Var("y")))
+            .argument("f2", Constructor("fib") & Constructor("at", Var("x")))
+            .suffix(Constructor("fib") & Constructor("at", Var("z"))),
+        ),
+    ]
 
     # CoSy instance with the component specifications and parameter space
-    cosy = CoSy(component_specifications)
+    cosy = CoSy(named_components_with_specifications)
 
     # query for Fibonacci numbers at relevant indices
     query: Type = Constructor("fib")

--- a/examples/example_fibonacci_linear.py
+++ b/examples/example_fibonacci_linear.py
@@ -52,18 +52,30 @@ def main():
         def __iter__(self):
             yield from frozenset(range(self._bound))
 
-    component_specifications = {
-        fst: SpecificationBuilder()
-        .parameter("x", Int())
-        .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
-        .suffix(Constructor("fib") & Constructor("at", Var("x"))),
-        fib_zero_one: SpecificationBuilder().suffix(Constructor("fibs") & Constructor("at", Literal(0))),
-        fib_next: SpecificationBuilder()
-        .parameter("y", Int())
-        .parameter("x", Int(), lambda vs: [vs["y"] - 1])
-        .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
-        .suffix(Constructor("fibs") & Constructor("at", Var("y"))),
-    }
+    component_specifications = [
+        (  #
+            "fst",
+            fst,
+            SpecificationBuilder()
+            .parameter("x", Int())
+            .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
+            .suffix(Constructor("fib") & Constructor("at", Var("x"))),
+        ),
+        (  #
+            "fib_zero_one",
+            fib_zero_one,
+            SpecificationBuilder().suffix(Constructor("fibs") & Constructor("at", Literal(0))),
+        ),
+        (  #
+            "fib_next",
+            fib_next,
+            SpecificationBuilder()
+            .parameter("y", Int())
+            .parameter("x", Int(), lambda vs: [vs["y"] - 1])
+            .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
+            .suffix(Constructor("fibs") & Constructor("at", Var("y"))),
+        ),
+    ]
 
     # CoSy instance with the component specifications and parameter space
     cosy = CoSy(component_specifications)

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -2,7 +2,6 @@ from collections.abc import Callable, Hashable, Iterable, Sequence
 from itertools import groupby
 from typing import Any, Generic, TypeVar
 
-from cosy.solution_space import SolutionSpace
 from cosy.specification_builder import SpecificationBuilder
 from cosy.subtypes import Subtypes, Taxonomy
 from cosy.synthesizer import Specification, Synthesizer
@@ -15,7 +14,6 @@ __all__ = [
     "Intersection",
     "Literal",
     "Omega",
-    "SolutionSpace",
     "SpecificationBuilder",
     "Subtypes",
     "Synthesizer",
@@ -36,10 +34,14 @@ class CoSy(Generic[T]):
         named_components_with_specifications: Sequence[tuple[T, Callable, Specification]],
         taxonomy: Taxonomy | None = None,
     ) -> None:
-        if len(list(groupby(named_components_with_specifications, key=lambda x: x[0]))) != len(
-            named_components_with_specifications
-        ):
-            msg = "Duplicate names: component's names should be unique"
+        duplicate_component_names = [key for key, group in groupby(named_components_with_specifications, key=lambda x: x[0]) if len(list(group)) > 1]
+        if len(duplicate_component_names) != 0:
+            msg = f"Component's names should be unique, but the following names are duplicated: {duplicate_component_names}"
+            raise ValueError(msg)
+
+        non_callable_interpretations_by_component_name = [name for name,interpretation,_ in named_components_with_specifications if not callable(interpretation)]
+        if len(non_callable_interpretations_by_component_name) != 0:
+            msg = f"Component's interpretations should be callable, but interpretations of components with the following names are not: {non_callable_interpretations_by_component_name}"
             raise ValueError(msg)
 
         self.named_components_with_specifications = named_components_with_specifications
@@ -65,9 +67,9 @@ class CoSy(Generic[T]):
         if not isinstance(query, Type):
             msg = "Query must be of type Type"
             raise TypeError(msg)
-        _solution_space = self._synthesizer.construct_solution_space(query).prune()
+        solution_space = self._synthesizer.construct_solution_space(query).prune()
 
-        trees = _solution_space.enumerate_trees(
+        trees = solution_space.enumerate_trees(
             query, max_count=max_count, interpretation=self.component_interpretations
         )
         for tree in trees:

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -34,12 +34,18 @@ class CoSy(Generic[T]):
         named_components_with_specifications: Sequence[tuple[T, Callable, Specification]],
         taxonomy: Taxonomy | None = None,
     ) -> None:
-        duplicate_component_names = [key for key, group in groupby(named_components_with_specifications, key=lambda x: x[0]) if len(list(group)) > 1]
+        duplicate_component_names = [
+            key
+            for key, group in groupby(named_components_with_specifications, key=lambda x: x[0])
+            if len(list(group)) > 1
+        ]
         if len(duplicate_component_names) != 0:
             msg = f"Component's names should be unique, but the following names are duplicated: {duplicate_component_names}"
             raise ValueError(msg)
 
-        non_callable_interpretations_by_component_name = [name for name,interpretation,_ in named_components_with_specifications if not callable(interpretation)]
+        non_callable_interpretations_by_component_name = [
+            name for name, interpretation, _ in named_components_with_specifications if not callable(interpretation)
+        ]
         if len(non_callable_interpretations_by_component_name) != 0:
             msg = f"Component's interpretations should be callable, but interpretations of components with the following names are not: {non_callable_interpretations_by_component_name}"
             raise ValueError(msg)

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -1,4 +1,5 @@
-from collections.abc import Hashable, Iterable, Mapping
+from collections.abc import Callable, Hashable, Iterable, Sequence
+from itertools import groupby
 from typing import Any, Generic, TypeVar
 
 from cosy.solution_space import SolutionSpace
@@ -26,18 +27,32 @@ T = TypeVar("T", bound=Hashable)
 
 
 class CoSy(Generic[T]):
-    component_specifications: Mapping[T, Specification]
+    named_component_with_specifications: Sequence[tuple[T, Callable, Specification]]
     taxonomy: Taxonomy | None = None
     _synthesizer: Synthesizer
 
     def __init__(
         self,
-        component_specifications: Mapping[T, Specification],
+        named_component_with_specifications: Sequence[tuple[T, Callable, Specification]],
         taxonomy: Taxonomy | None = None,
     ) -> None:
-        self.component_specifications = component_specifications
+        if len(list(groupby(named_component_with_specifications, key=lambda x: x[0]))) != len(
+            named_component_with_specifications
+        ):
+            msg = "Duplicate names: component's names should be unique"
+            raise ValueError(msg)
+
+        self.named_component_with_specifications = named_component_with_specifications
         self.taxonomy = taxonomy if taxonomy is not None else {}
-        self._synthesizer = Synthesizer(component_specifications, self.taxonomy)
+
+        self.component_specifications = {
+            name: specification for name, _, specification in self.named_component_with_specifications
+        }
+        self.component_interpretations = {
+            name: interpretation for name, interpretation, _ in self.named_component_with_specifications
+        }
+
+        self._synthesizer = Synthesizer(self.component_specifications, self.taxonomy)
 
     def solve(self, query: Type, max_count: int = 100) -> Iterable[Any]:
         """
@@ -50,8 +65,8 @@ class CoSy(Generic[T]):
         if not isinstance(query, Type):
             msg = "Query must be of type Type"
             raise TypeError(msg)
-        solution_space = self._synthesizer.construct_solution_space(query).prune()
+        _solution_space = self._synthesizer.construct_solution_space(query).prune()
 
-        trees = solution_space.enumerate_trees(query, max_count=max_count)
+        trees = _solution_space.enumerate_trees(query, max_count=max_count, interpretation=self.component_interpretations)
         for tree in trees:
-            yield tree.interpret()
+            yield tree.interpret(interpretation=self.component_interpretations)

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -27,29 +27,29 @@ T = TypeVar("T", bound=Hashable)
 
 
 class CoSy(Generic[T]):
-    named_component_with_specifications: Sequence[tuple[T, Callable, Specification]]
+    named_components_with_specifications: Sequence[tuple[T, Callable, Specification]]
     taxonomy: Taxonomy | None = None
     _synthesizer: Synthesizer
 
     def __init__(
         self,
-        named_component_with_specifications: Sequence[tuple[T, Callable, Specification]],
+        named_components_with_specifications: Sequence[tuple[T, Callable, Specification]],
         taxonomy: Taxonomy | None = None,
     ) -> None:
-        if len(list(groupby(named_component_with_specifications, key=lambda x: x[0]))) != len(
-            named_component_with_specifications
+        if len(list(groupby(named_components_with_specifications, key=lambda x: x[0]))) != len(
+            named_components_with_specifications
         ):
             msg = "Duplicate names: component's names should be unique"
             raise ValueError(msg)
 
-        self.named_component_with_specifications = named_component_with_specifications
+        self.named_components_with_specifications = named_components_with_specifications
         self.taxonomy = taxonomy if taxonomy is not None else {}
 
         self.component_specifications = {
-            name: specification for name, _, specification in self.named_component_with_specifications
+            name: specification for name, _, specification in self.named_components_with_specifications
         }
         self.component_interpretations = {
-            name: interpretation for name, interpretation, _ in self.named_component_with_specifications
+            name: interpretation for name, interpretation, _ in self.named_components_with_specifications
         }
 
         self._synthesizer = Synthesizer(self.component_specifications, self.taxonomy)
@@ -67,6 +67,8 @@ class CoSy(Generic[T]):
             raise TypeError(msg)
         _solution_space = self._synthesizer.construct_solution_space(query).prune()
 
-        trees = _solution_space.enumerate_trees(query, max_count=max_count, interpretation=self.component_interpretations)
+        trees = _solution_space.enumerate_trees(
+            query, max_count=max_count, interpretation=self.component_interpretations
+        )
         for tree in trees:
             yield tree.interpret(interpretation=self.component_interpretations)


### PR DESCRIPTION
This pull request replaces the repository dictionary with a list of tuples. 

The tuples consist of `(name: str, interpretation: Callable, specification: Specification)`. 
CoSy internally builds two dictionaries from this list: One mapping the names to their specification, and one mapping the names to their interpretation. 
The interpretation is supplied to the enumeration, this leads to constraints on the specifications containing the interpreted terms. 

This PR supersedes #18. 

Other changes: 

- #15 did not include the necessary changes to the quick start guide. This PR includes changes for both
- tudo-seal/cosy-lexers@1ecf5a3bebe31764d055a4b7075d14f1be3c57eb tudo-seal/cosy-lexers@18c6ef73897414fc699d63f09adcb8da6a46844c is updated to accomodate all the new "keywords" (`DataGroup`, `Group`, `SpecificationBuilder`)
- An additional example that shows how tuples allow inlining interpretations is added. 
- All examples, tests, and benchmarks have been updated accordingly. Test and benchmarks do not use tuples, as they do not use `CoSy`, and thus use the old dictionary structure. 

