### PR TITLE
Add dependabot.yml to keep workflows up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
With there being quite a few workflows in place in this project, updating them when new checkout actions etc. come out would be tedious. 

This tedium is avoided by dependabot, used solely for github actions, as else CoSy has no other dependencies. 