### PR TITLE
Add Benchmarking to CI and PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,7 @@ jobs:
         git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
 
     - name: Determine Push Or Not
-      # if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       run: echo "PUSH_TO_BENCHMARKS=true" >> $GITHUB_ENV
 
     - name: Store Benchmark Result

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,9 +33,16 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
+        repository: tudo-seal/cosy-benchmarks
+        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        ref: 'gh-pages'
+
+    - uses: actions/checkout@v4
+      with:
         # Full history for timestamps
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        path: 'cosy-nested'
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -47,20 +54,14 @@ jobs:
 
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
-
-    - uses: actions/checkout@v4
-      with:
-        repository: tudo-seal/cosy-benchmarks
-        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        ref: 'gh-pages'
-        path: 'cosy-benchmarks'
+      working-directory: 'cosy-nested'
 
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: benchmarks.json
+        output-file-path: cosy-nested/benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,7 +47,6 @@ jobs:
 
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
-      working-directory: ./cosy
 
     - name: XDTesting Print Directory Structure
       uses: FiorelaCiroku/XDTesting-Print-Directory-Structure@v1.0.2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
         tool: 'pytest'
         output-file-path: cosy-nested/benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        auto-push: false
+        auto-push: true
         alert-threshold: '300%'
         comment-on-alert: true
         fail-on-alert: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
         # Full history for timestamps
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        path: 'cosy'
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -47,12 +48,13 @@ jobs:
 
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
+      working-directory: ./cosy
 
     - uses: actions/checkout@v4
       with:
         repository: tudo-seal/cosy-benchmarks
+        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         ref: 'gh-pages'
-        path: 'cosy-benchmarks'
 
     - run: cd cosy-benchmarks
 
@@ -61,7 +63,7 @@ jobs:
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: ../benchmarks.json
+        output-file-path: ./cosy/benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,14 +56,14 @@ jobs:
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         ref: 'gh-pages'
 
-    - run: ls
+    - run: echo $(ls)
 
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: ./cosy/benchmarks.json
+        output-file-path: ./benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,6 +75,7 @@ jobs:
       run: |
         git config user.name "tudo-seal-workflows[bot]"
         git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
+        git remote show origin
         git commit --amend --reset-author --no-edit
         git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages
       env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,6 +31,12 @@ jobs:
         app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
         private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
 
+    - uses: actions/checkout@v4
+      with:
+        # Full history for timestamps
+        fetch-depth: 0
+        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+
     - name: Set Committer
       run: |
         git config user.name "tudo-seal-workflows[bot]"
@@ -56,4 +62,4 @@ jobs:
 
     - name: Push Benchmark Results
       if: github.event_name != 'pull_request'
-      run: git push 'https://you:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages
+      run: git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,6 +56,9 @@ jobs:
       run: hatch test benchmarks --benchmark-json benchmarks.json
       working-directory: ./cosy
 
+    - name: XDTesting Print Directory Structure
+      uses: FiorelaCiroku/XDTesting-Print-Directory-Structure@v1.0.2
+
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,14 @@ jobs:
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
 
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Hatch
+      uses: pypa/hatch@install
+
     - name: Set Committer
       run: |
         git config user.name "tudo-seal-workflows[bot]"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,14 +1,13 @@
 name: Perform Benchmarks
 
-on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
+on: push
+   # branches:
+     # - main
+     # - develop
+  #pull_request:
+   # branches:
+   #   - main
+    #  - develop
 
 
 concurrency:
@@ -46,29 +45,38 @@ jobs:
     - name: Install Hatch
       uses: pypa/hatch@install
 
-    - name: Set Committer
-      run: |
-        git config user.name "tudo-seal-workflows[bot]"
-        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
-
-    - name: Determine Push Or Not
-      # if: github.event_name != 'pull_request'
-      run: echo "PUSH_TO_BENCHMARKS=true" >> $GITHUB_ENV
-
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
+
+    - uses: actions/checkout@v4
+      with:
+        repository: tudo-seal/cosy-benchmarks
+        ref: 'gh-pages'
+        path: 'cosy-benchmarks'
+
+    - run: cd cosy-benchmarks
 
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: benchmarks.json
+        output-file-path: ../benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        auto-push: ${{ env.PUSH_TO_BENCHMARKS }}
+        auto-push: false
         alert-threshold: '300%'
         comment-on-alert: true
         fail-on-alert: true
         comment-always: true
         gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
         benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
+
+    - name: Push Benchmark Results
+      # if: github.event_name != 'pull_request'
+      run: |
+        git config user.name "tudo-seal-workflows[bot]"
+        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
+        git commit --amend --reset-author --no-edit
+        git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages
+      env:
+        GH_TOKEN: ${{ steps.tudo-seal-workflow-token.outputs.token }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,6 +56,8 @@ jobs:
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         ref: 'gh-pages'
 
+    - run: ls
+
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,6 +20,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+  PUSH_TO_BENCHMARKS: false
 
 jobs:
   benchmark-then-upload:
@@ -37,10 +38,10 @@ jobs:
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.13'
 
     - name: Install Hatch
       uses: pypa/hatch@install
@@ -49,6 +50,10 @@ jobs:
       run: |
         git config user.name "tudo-seal-workflows[bot]"
         git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
+
+    - name: Determine Push Or Not
+      # if: github.event_name != 'pull_request'
+      run: echo "PUSH_TO_BENCHMARKS=true" >> $GITHUB_ENV
 
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
@@ -60,14 +65,10 @@ jobs:
         tool: 'pytest'
         output-file-path: benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        auto-push: false
+        auto-push: ${{ env.PUSH_TO_BENCHMARKS }}
         alert-threshold: '300%'
         comment-on-alert: true
         fail-on-alert: true
         comment-always: true
         gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
         benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
-
-    - name: Push Benchmark Results
-      # if: github.event_name != 'pull_request'
-      run: git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,6 +33,12 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
+        repository: tudo-seal/cosy-benchmarks
+        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        ref: 'gh-pages'
+
+    - uses: actions/checkout@v4
+      with:
         # Full history for timestamps
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
@@ -49,14 +55,6 @@ jobs:
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
       working-directory: ./cosy
-
-    - uses: actions/checkout@v4
-      with:
-        repository: tudo-seal/cosy-benchmarks
-        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        ref: 'gh-pages'
-
-    - run: echo $(ls)
 
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,16 +33,9 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-        repository: tudo-seal/cosy-benchmarks
-        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        ref: 'gh-pages'
-
-    - uses: actions/checkout@v4
-      with:
         # Full history for timestamps
         fetch-depth: 0
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        path: 'cosy'
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -59,12 +52,19 @@ jobs:
     - name: XDTesting Print Directory Structure
       uses: FiorelaCiroku/XDTesting-Print-Directory-Structure@v1.0.2
 
+    - uses: actions/checkout@v4
+      with:
+        repository: tudo-seal/cosy-benchmarks
+        token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        ref: 'gh-pages'
+        path: 'cosy-benchmarks'
+
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: ./benchmarks.json
+        output-file-path: benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -81,5 +81,6 @@ jobs:
         comment-on-alert: true
         fail-on-alert: true
         comment-always: true
+        summary-always: true
         gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
         benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,13 +1,14 @@
 name: Perform Benchmarks
 
-on: push
-   # branches:
-     # - main
-     # - develop
-  #pull_request:
-   # branches:
-   #   - main
-    #  - develop
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 
 
 concurrency:
@@ -30,6 +31,9 @@ jobs:
       with:
         app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
         private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
+        repositories: |
+          cosy
+          cosy-benchmarks
 
     - uses: actions/checkout@v4
       with:
@@ -56,6 +60,15 @@ jobs:
       run: hatch test benchmarks --benchmark-json benchmarks.json
       working-directory: 'cosy-nested'
 
+    - name: Config Git
+      run: |
+        git config user.name "tudo-seal-workflows[bot]"
+        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
+
+    - name: Determine Push Or Not
+      # if: github.event_name != 'pull_request'
+      run: echo "PUSH_TO_BENCHMARKS=true" >> $GITHUB_ENV
+
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -63,22 +76,10 @@ jobs:
         tool: 'pytest'
         output-file-path: cosy-nested/benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        auto-push: true
+        auto-push: ${{ env.PUSH_TO_BENCHMARKS }}
         alert-threshold: '300%'
         comment-on-alert: true
         fail-on-alert: true
         comment-always: true
         gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
         benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
-
-    - name: Push Benchmark Results
-      # if: github.event_name != 'pull_request'
-      run: |
-        git config user.name "tudo-seal-workflows[bot]"
-        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
-        git remote show origin
-        git log -1
-        git commit --amend --reset-author --no-edit
-        git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages
-      env:
-        GH_TOKEN: ${{ steps.tudo-seal-workflow-token.outputs.token }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,9 +48,6 @@ jobs:
     - name: Run Benchmark Suite
       run: hatch test benchmarks --benchmark-json benchmarks.json
 
-    - name: XDTesting Print Directory Structure
-      uses: FiorelaCiroku/XDTesting-Print-Directory-Structure@v1.0.2
-
     - uses: actions/checkout@v4
       with:
         repository: tudo-seal/cosy-benchmarks
@@ -63,7 +60,7 @@ jobs:
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: ../benchmarks.json
+        output-file-path: benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,59 @@
+name: Perform Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+
+concurrency:
+  group: benchmarks-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
+  BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+
+jobs:
+  benchmark-then-upload:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/create-github-app-token@v2
+      id: tudo-seal-workflow-token
+      with:
+        app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
+        private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
+
+    - name: Set Committer
+      run: |
+        git config user.name "tudo-seal-workflows[bot]"
+        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
+
+    - name: Run Benchmark Suite
+      run: hatch test benchmarks --benchmark-json benchmarks.json
+
+    - name: Store Benchmark Result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Python Benchmark with pytest-benchmark
+        tool: 'pytest'
+        output-file-path: benchmarks.json
+        github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        auto-push: false
+        alert-threshold: '300%'
+        comment-on-alert: true
+        fail-on-alert: true
+        comment-always: true
+        gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
+        benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
+
+    - name: Push Benchmark Results
+      if: github.event_name != 'pull_request'
+      run: git push 'https://you:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         name: Python Benchmark with pytest-benchmark
         tool: 'pytest'
-        output-file-path: benchmarks.json
+        output-file-path: ../benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         auto-push: false
         alert-threshold: '300%'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:
-        name: Python Benchmark with pytest-benchmark
+        name: Benchmark CoSy
         tool: 'pytest'
         output-file-path: cosy-nested/benchmarks.json
         github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
@@ -77,6 +77,7 @@ jobs:
         git config user.name "tudo-seal-workflows[bot]"
         git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
         git remote show origin
+        git log -1
         git commit --amend --reset-author --no-edit
         git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages
       env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,5 +69,5 @@ jobs:
         benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
 
     - name: Push Benchmark Results
-      if: github.event_name != 'pull_request'
+      # if: github.event_name != 'pull_request'
       run: git push 'https://tudo-seal-workflows[bot]:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,8 +56,6 @@ jobs:
         token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
         ref: 'gh-pages'
 
-    - run: cd cosy-benchmarks
-
     - name: Store Benchmark Result
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Move nightly tag to current HEAD
         run: |
-          git config user.name "tudo-seal-workflow[bot]"
-          git config user.email "244727884+tudo-seal-workflow[bot]@users.noreply.github.com"
+          git config user.name "tudo-seal-workflows[bot]"
+          git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
           git tag -d ${{ env.nightly_tag }} || true
           git push origin :refs/tags/${{ env.nightly_tag }} || true
           git tag ${{ env.nightly_tag }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Move nightly tag to current HEAD
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "tudo-seal-workflow[bot]"
+          git config user.email "244727884+tudo-seal-workflow[bot]@users.noreply.github.com"
           git tag -d ${{ env.nightly_tag }} || true
           git push origin :refs/tags/${{ env.nightly_tag }} || true
           git tag ${{ env.nightly_tag }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,34 +71,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         flags: ${{ matrix.os }}-${{ matrix.python-version }}
-
-    - name: Run Benchmark Suite
-      run: hatch test benchmarks --benchmark-json benchmarks.json
-
-    - uses: actions/create-github-app-token@v2
-      id: tudo-seal-workflow-token
-      with:
-        app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
-        private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
-
-    - name: Store Benchmark Result
-      uses: benchmark-action/github-action-benchmark@v1
-      with:
-        name: Python Benchmark with pytest-benchmark
-        tool: 'pytest'
-        output-file-path: benchmarks.json
-        github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
-        auto-push: false
-        alert-threshold: '300%'
-        comment-on-alert: true
-        fail-on-alert: true
-        comment-always: true
-        gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
-        benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
-
-    - name: Push Benchmark Results
-      if: github.event_name != 'pull_request'
-      run: |
-        git config user.name "tudo-seal-workflows[bot]"
-        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
-        git push 'https://you:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
 
 jobs:
   test-lint-type-coverage:
@@ -70,3 +71,34 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         flags: ${{ matrix.os }}-${{ matrix.python-version }}
+
+    - name: Run Benchmark Suite
+      run: hatch test benchmarks --benchmark-json benchmarks.json
+
+    - uses: actions/create-github-app-token@v2
+      id: tudo-seal-workflow-token
+      with:
+        app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
+        private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
+
+    - name: Store Benchmark Result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Python Benchmark with pytest-benchmark
+        tool: 'pytest'
+        output-file-path: benchmarks.json
+        github-token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        auto-push: false
+        alert-threshold: '300%'
+        comment-on-alert: true
+        fail-on-alert: true
+        comment-always: true
+        gh-repository: 'github.com/tudo-seal/cosy-benchmarks'
+        benchmark-data-dir-path: '${{ env.BRANCH_NAME }}/benchmarks'
+
+    - name: Push Benchmark Results
+      if: github.event_name != 'pull_request'
+      run: |
+        git config user.name "tudo-seal-workflow[bot]"
+        git config user.email "244727884+tudo-seal-workflow[bot]@users.noreply.github.com"
+        git push 'https://you:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,6 +99,6 @@ jobs:
     - name: Push Benchmark Results
       if: github.event_name != 'pull_request'
       run: |
-        git config user.name "tudo-seal-workflow[bot]"
-        git config user.email "244727884+tudo-seal-workflow[bot]@users.noreply.github.com"
+        git config user.name "tudo-seal-workflows[bot]"
+        git config user.email "244727884+tudo-seal-workflows[bot]@users.noreply.github.com"
         git push 'https://you:${{ steps.tudo-seal-workflow-token.outputs.token }}@github.com/tudo-seal/cosy-benchmarks.git' gh-pages:gh-pages

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,8 +40,8 @@ jobs:
 
     - name: Configure Git for Actions
       run: |
-        git config --local user.name 'github-actions[bot]'
-        git config --local user.email 'github-actions[bot]@users.noreply.github.com'
+        git config --local user.name 'tudo-seal-workflow[bot]'
+        git config --local user.email '244727884+tudo-seal-workflow[bot]@users.noreply.github.com'
 
     - name: Publish
       run: hatch run docs:deploy

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,8 +40,8 @@ jobs:
 
     - name: Configure Git for Actions
       run: |
-        git config --local user.name 'tudo-seal-workflow[bot]'
-        git config --local user.email '244727884+tudo-seal-workflow[bot]@users.noreply.github.com'
+        git config --local user.name 'tudo-seal-workflows[bot]'
+        git config --local user.email '244727884+tudo-seal-workflows[bot]@users.noreply.github.com'
 
     - name: Publish
       run: hatch run docs:deploy


### PR DESCRIPTION
Recent changes to `CoSy` have lead to some overlooked performance regressions that the benchmarks would have caught. 

To make benchmarking more visible, benchmark results are now added to the PRs and compared with prior results. 

Additionally, https://github.com/tudo-seal/cosy-benchmarks will track the performance over time as graphs, so that we can look back in some time and see how much faster we still managed to make things. 