### PR TITLE
Additional security measure on PRs to 'develop' and 'main'

### DIFF
--- a/.github/workflows/pr-rules-develop.yml
+++ b/.github/workflows/pr-rules-develop.yml
@@ -13,18 +13,26 @@ jobs:
       checks: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: tudo-seal-workflow-token
+        with:
+          app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
+          private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
+
       - name: Close Pull Request and Comment if Violating
         uses: superbrothers/close-pull-request@v3
         if: ${{ !contains( github.head_ref, 'feature/') && !contains( github.head_ref, 'bugfix/') && !contains( github.head_ref, 'dependabot/github_actions/')}}
         with:
           comment: |
             :warning: You can only merge to develop from a feature or a bugfix branch. :warning:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+
       - name: Fail Job if Violating
         if: ${{ !contains( github.head_ref, 'feature/') && !contains( github.head_ref, 'bugfix/') && !contains( github.head_ref, 'dependabot/github_actions/')}}
         run: |
           echo "Reason: You can only merge to develop from a feature or a bugfix branch."
           exit 1
+
       - name: Succeed Job if not Violating
         if: ${{ contains( github.head_ref, 'feature/') || contains( github.head_ref, 'bugfix/') || contains( github.head_ref, 'dependabot/github_actions/')}}
         run: |

--- a/.github/workflows/pr-rules-develop.yml
+++ b/.github/workflows/pr-rules-develop.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - develop
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   pr-rules-main:
     runs-on: ubuntu-latest
@@ -20,12 +23,12 @@ jobs:
           private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
 
       - name: Close Pull Request and Comment if Violating
-        uses: superbrothers/close-pull-request@v3
         if: ${{ !contains( github.head_ref, 'feature/') && !contains( github.head_ref, 'bugfix/') && !contains( github.head_ref, 'dependabot/github_actions/')}}
-        with:
-          comment: |
-            :warning: You can only merge to develop from a feature or a bugfix branch. :warning:
-          github_token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+        run: |
+          gh pr comment ${{ env.PR_NUMBER }} --body ":warning: You can only merge to develop from a feature or a bugfix branch. :warning:"
+          gh pr close ${{ env.PR_NUMBER }}
+        env:
+          GH_TOKEN: ${{ steps.tudo-seal-workflow-token.outputs.token }}
 
       - name: Fail Job if Violating
         if: ${{ !contains( github.head_ref, 'feature/') && !contains( github.head_ref, 'bugfix/') && !contains( github.head_ref, 'dependabot/github_actions/')}}

--- a/.github/workflows/pr-rules-develop.yml
+++ b/.github/workflows/pr-rules-develop.yml
@@ -2,7 +2,7 @@ name: 'Check PR Rules for Develop'
 
 on:
   pull_request_target:
-    types: [ opened ]
+    types: [ opened, reopened ]
     branches:
       - develop
 

--- a/.github/workflows/pr-rules-main.yml
+++ b/.github/workflows/pr-rules-main.yml
@@ -2,7 +2,7 @@ name: 'Check PR Rules for Main'
 
 on:
   pull_request_target:
-    types: [ opened ]
+    types: [ opened, reopened ]
     branches:
       - main
 

--- a/.github/workflows/pr-rules-main.yml
+++ b/.github/workflows/pr-rules-main.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   pr-rules-main:
     runs-on: ubuntu-latest
@@ -13,13 +16,26 @@ jobs:
       checks: write
       pull-requests: write
     steps:
-      - name: Close Pull Request and Comment if Violating
-        uses: superbrothers/close-pull-request@v3
-        if: ${{ !contains( github.head_ref, 'release/') && !contains( github.head_ref, 'hotfix/')}}
+      - uses: actions/create-github-app-token@v2
+        id: tudo-seal-workflow-token
         with:
-          comment: |
-            :warning: You can only merge to main from a release or a hotfix branch. :warning:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.TUDO_SEAL_WORKFLOW_CLIENT_ID}}
+          private-key: ${{ secrets.TUDO_SEAL_WORKFLOW_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          # Full history for timestamps
+          fetch-depth: 0
+          token: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+
+      - name: Close Pull Request and Comment if Violating
+        if: ${{ !contains( github.head_ref, 'feature/') && !contains( github.head_ref, 'bugfix/') && !contains( github.head_ref, 'dependabot/github_actions/')}}
+        run: |
+          gh pr comment ${{ env.PR_NUMBER }} --body ":warning: You can only merge to main from a release or a hotfix branch. :warning:"
+          gh pr close ${{ env.PR_NUMBER }}
+        env:
+          GH_TOKEN: ${{ steps.tudo-seal-workflow-token.outputs.token }}
+
       - name: Fail Job if Violating
         if: ${{ !contains( github.head_ref, 'release/') && !contains( github.head_ref, 'hotfix/')}}
         run: |


### PR DESCRIPTION
Previously, reopening a closed PR would circumvent the branching rules. This is fixed by this. 