### PR TITLE
Update formatting of all files to be compatible with Hatch 1.16.1

### DIFF
--- a/benchmarks/test_benchmark_maximal_elements.py
+++ b/benchmarks/test_benchmark_maximal_elements.py
@@ -3,6 +3,7 @@
 from random import Random
 
 import pytest
+
 from cosy.combinatorics import maximal_elements
 
 

--- a/benchmarks/test_benchmark_maze.py
+++ b/benchmarks/test_benchmark_maze.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Mapping
 from itertools import product
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Specification, Synthesizer
 from cosy.types import Constructor, DataGroup, Literal, Type, Var
@@ -16,12 +17,10 @@ def is_free(pos: tuple[int, int]) -> bool:
 
 
 @pytest.fixture
-def component_specifications() -> (
-    Mapping[
-        Callable[[tuple[int, int], tuple[int, int], str], str] | str,
-        Specification,
-    ]
-):
+def component_specifications() -> Mapping[
+    Callable[[tuple[int, int], tuple[int, int], str], str] | str,
+    Specification,
+]:
     def up(b: tuple[int, int], _a: tuple[int, int], p: str) -> str:
         return f"{p} => UP({b})"
 

--- a/benchmarks/test_benchmark_maze_contains.py
+++ b/benchmarks/test_benchmark_maze_contains.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Mapping
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Specification, Synthesizer
 from cosy.types import Constructor, Group, Literal, Type, Var
@@ -18,12 +19,10 @@ SIZE = 50
 
 
 @pytest.fixture
-def component_specifications() -> (
-    Mapping[
-        Callable[[tuple[int, int], tuple[int, int], str], str] | str,
-        Specification,
-    ]
-):
+def component_specifications() -> Mapping[
+    Callable[[tuple[int, int], tuple[int, int], str], str] | str,
+    Specification,
+]:
     def up(b: tuple[int, int], _a: tuple[int, int], p: str) -> str:
         return f"{p} => UP({b})"
 

--- a/benchmarks/test_benchmark_maze_loopfree.py
+++ b/benchmarks/test_benchmark_maze_loopfree.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Iterable, Mapping
 from itertools import product
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Specification, Synthesizer
 from cosy.tree import Tree
@@ -17,12 +18,10 @@ def is_free(pos: tuple[int, int]) -> bool:
 
 
 @pytest.fixture
-def component_specifications() -> (
-    Mapping[
-        Callable[[tuple[int, int], tuple[int, int], str], str] | str,
-        Specification,
-    ]
-):
+def component_specifications() -> Mapping[
+    Callable[[tuple[int, int], tuple[int, int], str], str] | str,
+    Specification,
+]:
     def up(b: tuple[int, int], _a: tuple[int, int], p: str) -> str:
         return f"{p} => UP({b})"
 

--- a/docs/features/constraints.md
+++ b/docs/features/constraints.md
@@ -20,20 +20,20 @@ def one(s: str) -> str:
 ```
 These binary sequences are assigned names and specifications, forming a triple: 
 ```
-(  #
+(
     "empty",
     empty,
     SpecificationBuilder()
     .suffix(Constructor("str")),
 ),
-(  #
+(
     "zero",
     zero,
     SpecificationBuilder()
     .argument("s", Constructor("str"))
     .suffix(Constructor("str")),
 ),
-(  #
+(
     "one",
     one,
     SpecificationBuilder()
@@ -56,7 +56,7 @@ def fin(_b: bool, s: str) -> str:
 ```
 with triple: 
 ```
-(  #
+(
     "fin",
     fin,
     SpecificationBuilder()

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -32,19 +32,19 @@ def fib_next(_z: int, _y: int, _x: int, f1 : int, f2: int) -> int:
     return f1 + f2
 
 named_components_with_specifications = [
-        (  #
+        (
             "fib_zero",
             fib_zero,
             SpecificationBuilder()
             .suffix(Constructor("fib") & Constructor("at", Literal(0))),
         ),
-        (  #
+        (
             "fib_one",
             fib_one,
             SpecificationBuilder()
             .suffix(Constructor("fib") & Constructor("at", Literal(1))),
         ),
-        (  #
+        (
             "fib_next",
             fib_next,
             SpecificationBuilder()

--- a/examples/example_constraints.py
+++ b/examples/example_constraints.py
@@ -64,22 +64,22 @@ def main():
             pass
 
     named_components_with_specifications = [
-        (  #
+        (
             "empty",
             empty,
             SpecificationBuilder().suffix(Constructor("str")),
         ),
-        (  #
+        (
             "zero",
             zero,
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
-        (  #
+        (
             "one",
             one,
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
-        (  #
+        (
             "fin",
             fin,
             SpecificationBuilder()

--- a/examples/example_constraints_inline.py
+++ b/examples/example_constraints_inline.py
@@ -22,22 +22,22 @@ def main():
             pass
 
     named_components_with_specifications = [
-        (  #
+        (
             "empty",
             lambda: "",
             SpecificationBuilder().suffix(Constructor("str")),
         ),
-        (  #
+        (
             "zero",
             lambda s: s + "0",
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
-        (  #
+        (
             "one",
             lambda s: s + "1",
             SpecificationBuilder().argument("s", Constructor("str")).suffix(Constructor("str")),
         ),
-        (  #
+        (
             "fin",
             lambda _, s: s,
             SpecificationBuilder()

--- a/examples/example_fibonacci.py
+++ b/examples/example_fibonacci.py
@@ -46,17 +46,17 @@ def main():
     bound = 20
 
     named_components_with_specifications = [
-        (  #
+        (
             "fib_zero",
             fib_zero,
             SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(0))),
         ),
-        (  #
+        (
             "fib_one",
             fib_one,
             SpecificationBuilder().suffix(Constructor("fib") & Constructor("at", Literal(1))),
         ),
-        (  #
+        (
             "fib_next",
             fib_next,
             SpecificationBuilder()

--- a/examples/example_fibonacci_linear.py
+++ b/examples/example_fibonacci_linear.py
@@ -53,7 +53,7 @@ def main():
             yield from frozenset(range(self._bound))
 
     component_specifications = [
-        (  #
+        (
             "fst",
             fst,
             SpecificationBuilder()
@@ -61,12 +61,12 @@ def main():
             .argument("f", Constructor("fibs") & Constructor("at", Var("x")))
             .suffix(Constructor("fib") & Constructor("at", Var("x"))),
         ),
-        (  #
+        (
             "fib_zero_one",
             fib_zero_one,
             SpecificationBuilder().suffix(Constructor("fibs") & Constructor("at", Literal(0))),
         ),
-        (  #
+        (
             "fib_next",
             fib_next,
             SpecificationBuilder()

--- a/src/cosy/__init__.py
+++ b/src/cosy/__init__.py
@@ -1,9 +1,9 @@
 __all__ = [
     "Arrow",
     "Constructor",
-    "Maestro",
     "Intersection",
     "Literal",
+    "Maestro",
     "Omega",
     "SpecificationBuilder",
     "Subtypes",

--- a/src/cosy/specification_builder.py
+++ b/src/cosy/specification_builder.py
@@ -55,7 +55,7 @@ class SpecificationBuilder:
 
         self._result: Callable[[Specification], Specification] = lambda suffix: suffix
 
-    def parameter(  #
+    def parameter(
         self,
         name: str,
         group: Group,

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -3,6 +3,7 @@ from itertools import combinations
 from random import Random
 
 import pytest
+
 from cosy.combinatorics import maximal_elements, minimal_covers
 
 
@@ -45,9 +46,9 @@ def test_maximal_elements(elements) -> None:
         return all(a <= b for a, b in zip(x, y, strict=False))
 
     maximal = maximal_elements(elements, compare)
-    assert all(
-        any(compare(x, y) for y in maximal) for x in elements
-    ), "Some element is not dominated by maximal elements"
+    assert all(any(compare(x, y) for y in maximal) for x in elements), (
+        "Some element is not dominated by maximal elements"
+    )
 
     for i, x in enumerate(maximal):
         for j, y in enumerate(maximal):
@@ -62,22 +63,22 @@ def test_minimal_covers(sets, to_cover) -> None:
         to_cover,
         lambda s, e: e in s,
     )
-    assert all(
-        any(e in s for s in cover) for cover in covers for e in to_cover
-    ), "Some element is not covered by minimal covers"
+    assert all(any(e in s for s in cover) for cover in covers for e in to_cover), (
+        "Some element is not covered by minimal covers"
+    )
     assert all(s in sets for cover in covers for s in cover), "Some set in a cover is not included in sets"
 
     for i, cover1 in enumerate(covers):
         for j, cover2 in enumerate(covers):
             if i != j:
-                assert not all(
-                    s in cover2 for s in cover1
-                ), f"Minimal covers {cover1} and {cover2} are not incomparable"
+                assert not all(s in cover2 for s in cover1), (
+                    f"Minimal covers {cover1} and {cover2} are not incomparable"
+                )
 
     # check if all covers are found
     for i in range(len(sets) + 1):
         for cover in combinations(sets, i):
             if all(any(e in s for s in cover) for e in to_cover):
-                assert any(
-                    all(s in cover for s in cover2) for cover2 in covers
-                ), f"Cover {cover} is not found in minimal covers"
+                assert any(all(s in cover for s in cover2) for cover2 in covers), (
+                    f"Cover {cover} is not found in minimal covers"
+                )

--- a/tests/test_contains_tree.py
+++ b/tests/test_contains_tree.py
@@ -2,6 +2,7 @@
 from collections.abc import Callable
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree

--- a/tests/test_group_underspecification.py
+++ b/tests/test_group_underspecification.py
@@ -1,6 +1,8 @@
 # test for missing iter implementation in a Group subclass
+import re
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Synthesizer
 from cosy.types import Constructor, Group
@@ -27,6 +29,6 @@ def test_infinite_enumeration() -> None:
     synthesizer = Synthesizer(component_specifications)
     target = Constructor("c")
 
-    with pytest.raises(ValueError, match="Group contains is not iterable."):
+    with pytest.raises(ValueError, match=re.escape("Group contains is not iterable.")):
         # iter is necessary to determine the value of the literal variable x
         synthesizer.construct_solution_space(target)

--- a/tests/test_infinite_enumeration.py
+++ b/tests/test_infinite_enumeration.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterator
 
 import pytest
+
 from cosy.solution_space import SolutionSpace
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Synthesizer

--- a/tests/test_literal_inference.py
+++ b/tests/test_literal_inference.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 
 import pytest
+
 from cosy.specification_builder import SpecificationBuilder
 from cosy.synthesizer import Synthesizer
 from cosy.tree import Tree

--- a/tests/test_no_prune.py
+++ b/tests/test_no_prune.py
@@ -1,5 +1,6 @@
 # regression test for recursive unproductive specification
 import pytest
+
 from cosy.synthesizer import Synthesizer
 from cosy.types import Arrow, Constructor
 


### PR DESCRIPTION
Hatch 1.16.1 updates the ruff version used by `hatch fmt`. 
The new ruff version is slightly stricter than before, this PR updates all affected source files and corresponding indirect documentation links to sources. 