### PR TITLE
Add stable urls to nightly release

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Build Package
         run: hatch build
 
+      - name: Stable Url
+        run: |
+          cp dist/combinatory_synthesizer-${{ env.NIGHTLY_VERSION }}.tar.gz dist/combinatory_synthesizer.tar.gz
+          cp dist/combinatory_synthesizer-${{ env.NIGHTLY_VERSION }}.whl dist/combinatory_synthesizer-py3-none-any.whl
+
       - name: Convert nightly to draft
         run: gh release edit --draft "${{ env.nightly_tag }}" || true
         env:
@@ -75,4 +80,6 @@ jobs:
           GH_TOKEN: ${{ steps.tudo-seal-workflow-token.outputs.token }}
           ARTIFACTS: >
             dist/combinatory_synthesizer-${{ env.NIGHTLY_VERSION }}.tar.gz
+            dist/combinatory_synthesizer.tar.gz
             dist/combinatory_synthesizer-${{ env.NIGHTLY_VERSION }}-py3-none-any.whl
+            dist/combinatory_synthesizer-py3-none-any.whl

--- a/README.md
+++ b/README.md
@@ -49,7 +49,15 @@ Examples currently all employ the `Maestro`.
 Installation is as simple as running: 
 
 ```console
-pip install combinatory-synthesizer
+pip install --pre combinatory-synthesizer
+```
+
+Since `CoSy` is still in pre-release state, `PyPi` distributions are likely to be outdated most of the time. 
+
+If you want to stay up to date with a nightly build: 
+
+```console
+pip install https://github.com/tudo-seal/cosy/releases/download/nightly/combinatory_synthesizer-py3-none-any.whl
 ```
 
 `CoSy` itself has no dependencies at all, so it will play nice with any pre-existing projects.


### PR DESCRIPTION
This allows tools like pip to install an up-to-date version of CoSy in a more straightforward manner. 

For instance, adding the following line to the requirements file always updates to the latest nightly build: 

`https://github.com/tudo-seal/cosy/releases/download/nightly/combinatory_synthesizer-py3-none-any.whl`